### PR TITLE
feat: add support for copying files to new worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,33 @@ Supported template variables:
 - `{gitroot}`: repository root directory name
 
 Default: `../{gitroot}-wt`
+
+### `wt.copyignored`
+
+Copy files ignored by `.gitignore` (e.g., `.env`) to new worktrees.
+
+``` console
+$ git config wt.copyignored true
+```
+
+Default: `false`
+
+### `wt.copyuntracked`
+
+Copy untracked files (not yet added to git) to new worktrees.
+
+``` console
+$ git config wt.copyuntracked true
+```
+
+Default: `false`
+
+### `wt.copymodified`
+
+Copy modified files (tracked but with uncommitted changes) to new worktrees.
+
+``` console
+$ git config wt.copymodified true
+```
+
+Default: `false`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,19 @@ Configuration:
     Worktree base directory.
     Supported template variables: {gitroot} (repository root directory name)
     Default: ../{gitroot}-wt
-    Example: git config wt.basedir "../{gitroot}-worktrees"`,
+    Example: git config wt.basedir "../{gitroot}-worktrees"
+
+  wt.copyignored
+    Copy .gitignore'd files (e.g., .env) to new worktrees.
+    Default: false
+
+  wt.copyuntracked
+    Copy untracked files to new worktrees.
+    Default: false
+
+  wt.copymodified
+    Copy modified files to new worktrees.
+    Default: false`,
 	RunE:              runRoot,
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: completeBranches,
@@ -253,6 +265,12 @@ func handleWorktree(branch string) error {
 		return fmt.Errorf("failed to get worktree path: %w", err)
 	}
 
+	// Get copy options
+	copyOpts, err := git.GetCopyOptions()
+	if err != nil {
+		return fmt.Errorf("failed to get copy options: %w", err)
+	}
+
 	// Check if branch exists
 	exists, err := git.BranchExists(branch)
 	if err != nil {
@@ -261,12 +279,12 @@ func handleWorktree(branch string) error {
 
 	if exists {
 		// Branch exists, create worktree with existing branch
-		if err := git.AddWorktree(wtPath, branch); err != nil {
+		if err := git.AddWorktree(wtPath, branch, copyOpts); err != nil {
 			return fmt.Errorf("failed to create worktree: %w", err)
 		}
 	} else {
 		// Branch doesn't exist, create new branch and worktree
-		if err := git.AddWorktreeWithNewBranch(wtPath, branch); err != nil {
+		if err := git.AddWorktreeWithNewBranch(wtPath, branch, copyOpts); err != nil {
 			return fmt.Errorf("failed to create worktree with new branch: %w", err)
 		}
 	}

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -1,0 +1,188 @@
+package git
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	configKeyCopyIgnored   = "wt.copyignored"
+	configKeyCopyUntracked = "wt.copyuntracked"
+	configKeyCopyModified  = "wt.copymodified"
+)
+
+// CopyOptions holds the copy configuration.
+type CopyOptions struct {
+	CopyIgnored   bool
+	CopyUntracked bool
+	CopyModified  bool
+}
+
+// GetCopyOptions retrieves copy options from git config.
+func GetCopyOptions() (CopyOptions, error) {
+	opts := CopyOptions{}
+
+	val, err := GetConfig(configKeyCopyIgnored)
+	if err != nil {
+		return opts, err
+	}
+	opts.CopyIgnored = val == "true"
+
+	val, err = GetConfig(configKeyCopyUntracked)
+	if err != nil {
+		return opts, err
+	}
+	opts.CopyUntracked = val == "true"
+
+	val, err = GetConfig(configKeyCopyModified)
+	if err != nil {
+		return opts, err
+	}
+	opts.CopyModified = val == "true"
+
+	return opts, nil
+}
+
+// CopyFilesToWorktree copies files to the new worktree based on options.
+func CopyFilesToWorktree(srcRoot, dstRoot string, opts CopyOptions) error {
+	var files []string
+
+	if opts.CopyIgnored {
+		ignored, err := listIgnoredFiles(srcRoot)
+		if err != nil {
+			return err
+		}
+		files = append(files, ignored...)
+	}
+
+	if opts.CopyUntracked {
+		untracked, err := listUntrackedFiles(srcRoot)
+		if err != nil {
+			return err
+		}
+		files = append(files, untracked...)
+	}
+
+	if opts.CopyModified {
+		modified, err := listModifiedFiles(srcRoot)
+		if err != nil {
+			return err
+		}
+		files = append(files, modified...)
+	}
+
+	// Remove duplicates
+	seen := make(map[string]struct{})
+	for _, file := range files {
+		if _, exists := seen[file]; exists {
+			continue
+		}
+		seen[file] = struct{}{}
+
+		src := filepath.Join(srcRoot, file)
+		dst := filepath.Join(dstRoot, file)
+
+		if err := copyFile(src, dst); err != nil {
+			// Skip files that fail to copy (e.g., permission issues)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// listIgnoredFiles returns files ignored by .gitignore.
+func listIgnoredFiles(root string) ([]string, error) {
+	cmd, err := gitCommand("ls-files", "--others", "--ignored", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseFileList(string(out)), nil
+}
+
+// listUntrackedFiles returns untracked files (not ignored).
+func listUntrackedFiles(root string) ([]string, error) {
+	cmd, err := gitCommand("ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseFileList(string(out)), nil
+}
+
+// listModifiedFiles returns tracked files with modifications.
+func listModifiedFiles(root string) ([]string, error) {
+	cmd, err := gitCommand("ls-files", "--modified")
+	if err != nil {
+		return nil, err
+	}
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseFileList(string(out)), nil
+}
+
+func parseFileList(out string) []string {
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Skip .git directory
+		if strings.HasPrefix(line, ".git/") {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files
+}
+
+func copyFile(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	// Skip directories
+	if srcInfo.IsDir() {
+		return nil
+	}
+
+	// Create parent directory
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	// Preserve file permissions
+	return os.Chmod(dst, srcInfo.Mode())
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -100,7 +100,13 @@ func FindWorktreeByBranch(branch string) (*Worktree, error) {
 }
 
 // AddWorktree creates a new worktree for the given branch.
-func AddWorktree(path, branch string) error {
+func AddWorktree(path, branch string, copyOpts CopyOptions) error {
+	// Get source root before creating worktree
+	srcRoot, err := GetRepoRoot()
+	if err != nil {
+		return err
+	}
+
 	// Ensure parent directory exists
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
@@ -114,11 +120,26 @@ func AddWorktree(path, branch string) error {
 	// Output git messages to stderr so stdout only contains the path for shell integration
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Copy files to new worktree
+	if err := CopyFilesToWorktree(srcRoot, path, copyOpts); err != nil {
+		return fmt.Errorf("failed to copy files: %w", err)
+	}
+
+	return nil
 }
 
 // AddWorktreeWithNewBranch creates a new worktree with a new branch.
-func AddWorktreeWithNewBranch(path, branch string) error {
+func AddWorktreeWithNewBranch(path, branch string, copyOpts CopyOptions) error {
+	// Get source root before creating worktree
+	srcRoot, err := GetRepoRoot()
+	if err != nil {
+		return err
+	}
+
 	// Ensure parent directory exists
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
@@ -132,7 +153,16 @@ func AddWorktreeWithNewBranch(path, branch string) error {
 	// Output git messages to stderr so stdout only contains the path for shell integration
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Copy files to new worktree
+	if err := CopyFilesToWorktree(srcRoot, path, copyOpts); err != nil {
+		return fmt.Errorf("failed to copy files: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveWorktree removes a worktree.


### PR DESCRIPTION
Introduce options to copy ignored, untracked, and modified files to new worktrees. These options are configurable via git config:

- `wt.copyignored`: Copy files ignored by `.gitignore`.
- `wt.copyuntracked`: Copy untracked files.
- `wt.copymodified`: Copy modified files.