### PR TITLE
fix: add `--ignore-switch-directory` option for shell initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ git-wt --init fish | source
 Invoke-Expression (git-wt --init powershell | Out-String)
 ```
 
+> [!IMPORTANT]
+> The shell integration creates a `git()` wrapper function to enable automatic directory switching with `git wt <branch>`. This wrapper intercepts only `git wt <branch>` commands and passes all other git commands through unchanged. If you have other tools or customizations that also wrap the `git` command, there may be conflicts.
+
+If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--ignore-switch-directory` option:
+
+``` zsh
+eval "$(git-wt --init zsh --ignore-switch-directory)"
+```
+
 ## Configuration
 
 Configuration is done via `git config`.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,12 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
-const bashHook = `
-# git-wt shell hook for bash
+// Bash hooks.
+const bashGitWrapper = `
+# Override git command to cd after 'git wt <branch>'
 git() {
     if [[ "$1" == "wt" && -n "$2" && "$2" != -* ]]; then
         local result
@@ -17,48 +16,30 @@ git() {
         if [[ $exit_code -eq 0 && -d "$result" ]]; then
             cd "$result"
         else
+            echo "$result"
             return $exit_code
         fi
     else
         command git "$@"
     fi
 }
-
-# git wt completion for bash
-_git_wt_completion() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    if [[ "${COMP_WORDS[1]}" == "wt" && $COMP_CWORD -eq 2 ]]; then
-        local branches
-        branches=$(git-wt __complete "$cur" 2>/dev/null | grep -v '^:')
-        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
-        return 0
-    fi
-    return 1
-}
-
-# Hook into git completion
-if type -t __git_wrap__git_main &>/dev/null; then
-    _git_wt_orig_completion=$(complete -p git 2>/dev/null)
-    _git_wt_wrapper() {
-        if [[ "${COMP_WORDS[1]}" == "wt" ]]; then
-            _git_wt_completion && return
-        fi
-        __git_wrap__git_main
-    }
-    complete -o bashdefault -o default -o nospace -F _git_wt_wrapper git
-elif type -t _git &>/dev/null; then
-    _git_wt_wrapper() {
-        if [[ "${COMP_WORDS[1]}" == "wt" ]]; then
-            _git_wt_completion && return
-        fi
-        _git
-    }
-    complete -o bashdefault -o default -o nospace -F _git_wt_wrapper git
-fi
 `
 
-const zshHook = `
-# git-wt shell hook for zsh
+const bashCompletion = `
+# git wt <branch> completion for bash
+# Function name follows Git convention: _git_<subcommand>
+_git_wt() {
+    local cur prev words cword
+    _get_comp_words_by_ref -n =: cur prev words cword 2>/dev/null || {
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    }
+    __gitcomp_nl "$(command git-wt __complete "" 2>/dev/null | grep -v '^:')"
+}
+`
+
+// Zsh hooks.
+const zshGitWrapper = `
+# Override git command to cd after 'git wt <branch>'
 git() {
     if [[ "$1" == "wt" && -n "$2" && "$2" != -* ]]; then
         local result
@@ -67,38 +48,28 @@ git() {
         if [[ $exit_code -eq 0 && -d "$result" ]]; then
             cd "$result"
         else
+            echo "$result"
             return $exit_code
         fi
     else
         command git "$@"
     fi
 }
-
-# git wt completion for zsh
-_git-wt-completion() {
-    if [[ "${words[2]}" == "wt" ]]; then
-        local completions
-        completions=(${(f)"$(git-wt __complete "${words[3]:-}" 2>/dev/null | grep -v '^:')"})
-        _describe 'branch' completions
-        return 0
-    fi
-    return 1
-}
-
-# Hook into git completion
-if (( $+functions[_git] )); then
-    _git-wt-orig-git() { _git "$@" }
-    _git() {
-        if [[ "${words[2]}" == "wt" ]]; then
-            _git-wt-completion && return
-        fi
-        _git-wt-orig-git "$@"
-    }
-fi
 `
 
-const fishHook = `
-# git-wt shell hook for fish
+const zshCompletion = `
+# git wt <branch> completion for zsh
+# Must be compatible with ksh emulation (Git calls: emulate ksh -c $completion_func)
+_git_wt() {
+    local branches
+    branches="$(command git-wt __complete "" 2>/dev/null | grep -v '^:')"
+    __gitcomp_nl "$branches"
+}
+`
+
+// Fish hooks.
+const fishGitWrapper = `
+# Override git command to cd after 'git wt <branch>'
 function git --wraps git
     if test "$argv[1]" = "wt" -a -n "$argv[2]" -a (string sub -l 1 -- "$argv[2]") != "-"
         set -l result (command git wt $argv[2])
@@ -106,16 +77,19 @@ function git --wraps git
         if test $exit_code -eq 0 -a -d "$result"
             cd "$result"
         else
+            echo "$result"
             return $exit_code
         end
     else
         command git $argv
     end
 end
+`
 
-# git wt completion for fish
+const fishCompletion = `
+# git wt <branch> completion for fish
 function __fish_git_wt_branches
-    git-wt __complete "" 2>/dev/null | string match -rv '^:'
+    command git-wt __complete "" 2>/dev/null | string match -rv '^:'
 end
 
 function __fish_git_wt_needs_branch
@@ -126,27 +100,32 @@ end
 complete -c git -n '__fish_git_wt_needs_branch' -f -a '(__fish_git_wt_branches)'
 `
 
-const powershellHook = `
-# git-wt shell hook for PowerShell
-function git {
+// PowerShell hooks.
+const powershellGitWrapper = `
+# Override git command to cd after 'git wt <branch>'
+function Invoke-Git {
     if ($args[0] -eq "wt" -and $args[1] -and $args[1] -notlike "-*") {
-        $result = & git-wt $args[1] 2>&1
+        $result = & git.exe wt $args[1] 2>&1
         if ($LASTEXITCODE -eq 0 -and (Test-Path $result -PathType Container)) {
             Set-Location $result
         } else {
+            Write-Output $result
             return $LASTEXITCODE
         }
     } else {
         & git.exe @args
     }
 }
+Set-Alias -Name git -Value Invoke-Git -Option AllScope
+`
 
-# git wt completion for PowerShell
+const powershellCompletion = `
+# git wt <branch> completion for PowerShell
 $scriptBlock = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $tokens = $commandAst.ToString() -split '\s+'
     if ($tokens.Count -ge 2 -and $tokens[1] -eq "wt") {
-        $branches = git-wt __complete $wordToComplete 2>$null | Where-Object { $_ -notmatch '^:' }
+        $branches = & git-wt.exe __complete $wordToComplete 2>$null | Where-Object { $_ -notmatch '^:' }
         $branches | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -155,31 +134,35 @@ $scriptBlock = {
 Register-ArgumentCompleter -Native -CommandName git -ScriptBlock $scriptBlock
 `
 
-func runInit(cmd *cobra.Command, shell string) error {
+func runInit(shell string, ignoreSwitchDirectory bool) error {
 	switch shell {
 	case "bash":
-		if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
-			return err
+		fmt.Fprint(os.Stdout, "# git-wt shell hook for bash\n")
+		if !ignoreSwitchDirectory {
+			fmt.Fprint(os.Stdout, bashGitWrapper)
 		}
-		fmt.Fprint(os.Stdout, bashHook)
+		fmt.Fprint(os.Stdout, bashCompletion)
 		return nil
 	case "zsh":
-		if err := cmd.Root().GenZshCompletion(os.Stdout); err != nil {
-			return err
+		fmt.Fprint(os.Stdout, "# git-wt shell hook for zsh\n")
+		if !ignoreSwitchDirectory {
+			fmt.Fprint(os.Stdout, zshGitWrapper)
 		}
-		fmt.Fprint(os.Stdout, zshHook)
+		fmt.Fprint(os.Stdout, zshCompletion)
 		return nil
 	case "fish":
-		if err := cmd.Root().GenFishCompletion(os.Stdout, true); err != nil {
-			return err
+		fmt.Fprint(os.Stdout, "# git-wt shell hook for fish\n")
+		if !ignoreSwitchDirectory {
+			fmt.Fprint(os.Stdout, fishGitWrapper)
 		}
-		fmt.Fprint(os.Stdout, fishHook)
+		fmt.Fprint(os.Stdout, fishCompletion)
 		return nil
 	case "powershell":
-		if err := cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout); err != nil {
-			return err
+		fmt.Fprint(os.Stdout, "# git-wt shell hook for PowerShell\n")
+		if !ignoreSwitchDirectory {
+			fmt.Fprint(os.Stdout, powershellGitWrapper)
 		}
-		fmt.Fprint(os.Stdout, powershellHook)
+		fmt.Fprint(os.Stdout, powershellCompletion)
 		return nil
 	default:
 		return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish, powershell)", shell)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,9 +33,10 @@ import (
 )
 
 var (
-	deleteFlag      bool
-	forceDeleteFlag bool
-	initShell       string
+	deleteFlag            bool
+	forceDeleteFlag       bool
+	initShell             string
+	ignoreSwitchDirectory bool
 )
 
 var rootCmd = &cobra.Command{
@@ -101,12 +102,13 @@ func init() {
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
+	rootCmd.Flags().BoolVar(&ignoreSwitchDirectory, "ignore-switch-directory", false, "Do not add git() wrapper for automatic directory switching (use with --init)")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
 	// Handle init flag
 	if initShell != "" {
-		return runInit(cmd, initShell)
+		return runInit(initShell, ignoreSwitchDirectory)
 	}
 
 	// No arguments: list worktrees


### PR DESCRIPTION
This update introduces the `--ignore-switch-directory` option to the `--init` flag, allowing users to generate shell initialization scripts without the `git()` wrapper for automatic directory switching. This provides greater flexibility for users with custom setups or conflicting wrappers.