### PR TITLE
fix: rename `ignore-switch-directory` flag to `no-switch-directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Invoke-Expression (git-wt --init powershell | Out-String)
 > [!IMPORTANT]
 > The shell integration creates a `git()` wrapper function to enable automatic directory switching with `git wt <branch>`. This wrapper intercepts only `git wt <branch>` commands and passes all other git commands through unchanged. If you have other tools or customizations that also wrap the `git` command, there may be conflicts.
 
-If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--ignore-switch-directory` option:
+If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--no-switch-directory` option:
 
 ``` zsh
-eval "$(git-wt --init zsh --ignore-switch-directory)"
+eval "$(git-wt --init zsh --no-switch-directory)"
 ```
 
 ## Configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,10 +33,10 @@ import (
 )
 
 var (
-	deleteFlag            bool
-	forceDeleteFlag       bool
-	initShell             string
-	ignoreSwitchDirectory bool
+	deleteFlag          bool
+	forceDeleteFlag     bool
+	initShell           string
+	noSwitchDirectory   bool
 )
 
 var rootCmd = &cobra.Command{
@@ -102,13 +102,13 @@ func init() {
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
-	rootCmd.Flags().BoolVar(&ignoreSwitchDirectory, "ignore-switch-directory", false, "Do not add git() wrapper for automatic directory switching (use with --init)")
+	rootCmd.Flags().BoolVar(&noSwitchDirectory, "no-switch-directory", false, "Do not add git() wrapper for automatic directory switching (use with --init)")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
 	// Handle init flag
 	if initShell != "" {
-		return runInit(initShell, ignoreSwitchDirectory)
+		return runInit(initShell, noSwitchDirectory)
 	}
 
 	// No arguments: list worktrees


### PR DESCRIPTION
This pull request updates the option name for disabling the automatic directory switching feature in the shell integration, replacing `--ignore-switch-directory` with `--no-switch-directory` for clarity and consistency. The documentation and codebase have both been updated to reflect this change.

**User-facing changes:**

* Updated the CLI flag from `--ignore-switch-directory` to `--no-switch-directory` for disabling the `git()` wrapper function that handles automatic directory switching. (`cmd/root.go`, `README.md`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL39-R39) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL105-R111) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R66)

**Documentation updates:**

* Revised usage examples and explanations in `README.md` to use the new `--no-switch-directory` flag.