### PR TITLE
Fix git-wt fish hook output formatting

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -155,11 +155,17 @@ func runInit(shell string, ignoreSwitchDirectory bool) error {
 		fmt.Fprint(os.Stdout, zshCompletion)
 		return nil
 	case "fish":
-		io.WriteString(os.Stdout, "# git-wt shell hook for fish\n")
-		if !ignoreSwitchDirectory {
-			io.WriteString(os.Stdout, fishGitWrapper)
+		if _, err := io.WriteString(os.Stdout, "# git-wt shell hook for fish\n"); err != nil {
+			return err
 		}
-		io.WriteString(os.Stdout, fishCompletion)
+		if !ignoreSwitchDirectory {
+			if _, err := io.WriteString(os.Stdout, fishGitWrapper); err != nil {
+				return err
+			}
+		}
+		if _, err := io.WriteString(os.Stdout, fishCompletion); err != nil {
+			return err
+		}
 		return nil
 	case "powershell":
 		fmt.Fprint(os.Stdout, "# git-wt shell hook for PowerShell\n")


### PR DESCRIPTION
The fish hook from git-wt --init fish captures command output into a variable, which collapses newlines and breaks the table formatting for git wt.
This change collects the output as a single string and prints it with printf, preserving newlines.
Behavior is unchanged otherwise (still auto-cd on success).
Testing:

Manual: git wt output stays aligned; git wt <branch> still cds on success.


before
```
repo  on  main
/path/to/repo
➜  git wt
                              PATH                             BRANCH   HEAD     *  /path/to/repo                                main    abc1234      /path/to/repo-wt/feature-a                 feature-a  def5678      /path/to/repo-wt/feature-b                 feature-b  abc1234
```

after
```
repo  on  main
/path/to/repo
➜  git wt
                              PATH                             BRANCH   HEAD
 *  /path/to/repo                                main      abc1234
    /path/to/repo-wt/feature-a                   feature-a def5678
    /path/to/repo-wt/feature-b                   feature-b abc1234
```