### PR TITLE
fix: ensure worktrees use correct base directory when created from another worktree

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -491,6 +491,17 @@ func TestE2E_WorktreeFromWorktree(t *testing.T) {
 	if _, err := os.Stat(wt2Path); os.IsNotExist(err) {
 		t.Errorf("second worktree was not created at %s", wt2Path)
 	}
+
+	// Verify worktree paths are created under the same basedir
+	expectedWt1Path := filepath.Clean(filepath.Join(repo.Root, "../repo-wt/feature1"))
+	if wt1Path != expectedWt1Path {
+		t.Errorf("first worktree path = %q, want %q", wt1Path, expectedWt1Path)
+	}
+
+	expectedWt2Path := filepath.Clean(filepath.Join(repo.Root, "../repo-wt/feature2"))
+	if wt2Path != expectedWt2Path {
+		t.Errorf("second worktree path = %q, want %q", wt2Path, expectedWt2Path)
+	}
 }
 
 func TestE2E_CopyIgnored(t *testing.T) {

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -72,7 +72,7 @@ func MainRepoRoot(ctx context.Context) (string, error) {
 
 // RepoName returns the name of the current git repository (directory name).
 func RepoName(ctx context.Context) (string, error) {
-	root, err := RepoRoot(ctx)
+	root, err := MainRepoRoot(ctx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

When creating a worktree from within another worktree (e.g., `git wt a → git wt b`), the base directory for the second worktree was not set correctly.

Specifically:
- Expected behavior: worktrees should be created at `../{reponame}-wt/b`
- Actual behavior: worktrees were created at `../a-wt/b` instead

## Solution

Changed `RepoName()` which is used by `{gitroot}` to use `MainRepoRoot()` instead of `RepoRoot()`. This ensures that even when called from within a worktree, it correctly identifies the main repository root and returns the proper repository name.

## Additional Notes

Sorry if it's an intended behavior 😌 