### PR TITLE
feat: allow `--no-switch-directory` with `git wt <branch>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ If you want only completion without the `git()` wrapper (no automatic directory 
 eval "$(git wt --init zsh --no-switch-directory)"
 ```
 
+You can also use `--no-switch-directory` with `git wt <branch>` to create/switch to a worktree without changing the current directory:
+
+``` console
+$ git wt --no-switch-directory feature-branch
+/path/to/worktree/feature-branch  # prints path but stays in current directory
+```
+
 ## Configuration
 
 Configuration is done via `git config`. All config options can be overridden with flags for a single invocation.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,7 +118,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
-	rootCmd.Flags().BoolVar(&noSwitchDirectory, "no-switch-directory", false, "Do not add git() wrapper for automatic directory switching (use with --init)")
+	rootCmd.Flags().BoolVar(&noSwitchDirectory, "no-switch-directory", false, "Do not switch directory after creating/switching worktree (also disables git() wrapper when used with --init)")
 	// Config override flags.
 	rootCmd.Flags().StringVar(&basedirFlag, "basedir", "", "Override wt.basedir config (worktree base directory)")
 	rootCmd.Flags().BoolVar(&copyignoredFlag, "copyignored", false, "Override wt.copyignored config (copy .gitignore'd files)")


### PR DESCRIPTION
This pull request enhances the `--no-switch-directory` flag to allow users to create or switch worktrees without automatically changing directories in all supported shell integrations. It updates the flag's behavior, improves the documentation, and adds comprehensive end-to-end tests to verify correct shell integration across multiple shells.

**Shell integration improvements:**

* Updated the shell wrapper scripts for Bash, Zsh, Fish, and PowerShell to respect the `--no-switch-directory` flag, so that when this flag is used with `git wt <branch>`, the shell does not automatically change directories but instead prints the worktree path. [[1]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR15-R31) [[2]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR60-R76) [[3]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR102-R116) [[4]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR147-R154)

**Documentation updates:**

* Improved the `README.md` with an example and clearer explanation of how to use the `--no-switch-directory` flag to create or switch worktrees without changing the current directory.

**Flag behavior clarification:**

* Updated the flag description in `cmd/root.go` to clarify that `--no-switch-directory` disables automatic directory switching after creating or switching a worktree and also disables the shell wrapper when used with `--init`.

**Testing enhancements:**

* Added an end-to-end test to verify that the `--no-switch-directory` flag works correctly in Bash, Zsh, and Fish shell integrations by ensuring the shell does not change directories after running `git wt --no-switch-directory <branch>`.