### PR TITLE
feat: add `wt.hooks` config and `--hook` flag to run commands after creating new worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,18 @@ Supported patterns (same as `.gitignore`):
 - `vendor/`: directory matching
 - `**/temp`: match in any directory
 - `/config.local`: relative to git root
+
+#### `wt.hooks` / `--hook`
+
+Commands to run after creating a new worktree. Hooks run in the new worktree directory.
+
+``` console
+$ git config --add wt.hooks "npm install"
+$ git config --add wt.hooks "go generate ./..."
+# or override for a single invocation (multiple hooks supported)
+$ git wt --hook "npm install" feature-branch
+```
+
+> [!NOTE]
+> - Hooks only run when **creating** a new worktree, not when switching to an existing one.
+> - If a hook fails, execution stops immediately and `git wt` exits with an error (shell integration will not `cd` to the worktree).

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -16,6 +16,7 @@ const (
 	configKeyCopyUntracked = "wt.copyuntracked"
 	configKeyCopyModified  = "wt.copymodified"
 	configKeyNoCopy        = "wt.nocopy"
+	configKeyHooks         = "wt.hooks"
 )
 
 // Config holds all wt configuration values.
@@ -25,6 +26,7 @@ type Config struct {
 	CopyUntracked bool
 	CopyModified  bool
 	NoCopy        []string
+	Hooks         []string
 }
 
 // GitConfig retrieves all git config values for a key.
@@ -139,6 +141,13 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return cfg, err
 	}
 	cfg.NoCopy = noCopy
+
+	// Hooks
+	hooks, err := GitConfig(ctx, configKeyHooks)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Hooks = hooks
 
 	return cfg, nil
 }

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/k1LoW/exec"
+)
+
+// RunHooks executes the configured hooks in the given directory.
+// Hook stdout/stderr are written to the provided writer.
+// If a hook fails, it stops immediately and returns the error.
+func RunHooks(ctx context.Context, hooks []string, dir string, w io.Writer) error {
+	for _, hook := range hooks {
+		cmd := exec.CommandContext(ctx, "sh", "-c", hook)
+		cmd.Dir = dir
+		cmd.Stdout = w
+		cmd.Stderr = w
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("hook %q failed: %w", hook, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request adds support for post-worktree creation hooks, allowing users to specify commands that automatically run after creating a new worktree. Hooks can be configured globally via `wt.hooks` in git config or per-invocation using the new `--hook` flag. The implementation ensures hooks only run when a new worktree is created (not when switching to an existing one), and stops execution if any hook fails. Comprehensive end-to-end tests are included to verify correct behavior and error handling.

**New hook feature:**

* Added support for `wt.hooks` config and `--hook` flag to specify commands to run after creating a new worktree. Hooks run in the new worktree directory and can be set multiple times. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR49) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL103-R111) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR136) [[4]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR19) [[5]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR29) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R150-R164)
* Implemented `RunHooks` in `internal/git/hook.go` to execute hooks, writing output to stderr and stopping on the first failure.
* Integrated hook execution into the worktree creation flow, ensuring hooks run only after a new worktree is created and before shell integration changes directory.

**Configuration and override logic:**

* Modified config loading and CLI flag handling so that the `--hook` flag overrides the `wt.hooks` config if specified. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR189-R191) [[2]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR145-R151)
