### PR TITLE
fix: rename config key `wt.hooks` to `wt.hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ Supported patterns (same as `.gitignore`):
 - `**/temp`: match in any directory
 - `/config.local`: relative to git root
 
-#### `wt.hooks` / `--hook`
+#### `wt.hook` / `--hook`
 
 Commands to run after creating a new worktree. Hooks run in the new worktree directory.
 
 ``` console
-$ git config --add wt.hooks "npm install"
-$ git config --add wt.hooks "go generate ./..."
+$ git config --add wt.hook "npm install"
+$ git config --add wt.hook "go generate ./..."
 # or override for a single invocation (multiple hooks supported)
 $ git wt --hook "npm install" feature-branch
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,12 +103,12 @@ Configuration:
     Example: git config --add wt.nocopy "*.log"
              git config --add wt.nocopy "vendor/"
 
-  wt.hooks (--hook)
+  wt.hook (--hook)
     Commands to run after creating a new worktree.
     Can be specified multiple times. Hooks run in the new worktree directory.
     Note: Hooks do NOT run when switching to an existing worktree.
-    Example: git config --add wt.hooks "npm install"
-             git config --add wt.hooks "go generate ./..."`,
+    Example: git config --add wt.hook "npm install"
+             git config --add wt.hook "go generate ./..."`,
 	RunE:              runRoot,
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: completeBranches,

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1203,7 +1203,7 @@ func TestE2E_HookFlag(t *testing.T) {
 	}
 }
 
-// TestE2E_HookConfig tests the wt.hooks config runs commands after creating a new worktree.
+// TestE2E_HookConfig tests the wt.hook config runs commands after creating a new worktree.
 func TestE2E_HookConfig(t *testing.T) {
 	binPath := buildBinary(t)
 
@@ -1212,7 +1212,7 @@ func TestE2E_HookConfig(t *testing.T) {
 	repo.Commit("initial commit")
 
 	// Set hook in config
-	repo.Git("config", "--add", "wt.hooks", "touch config-hook-marker.txt")
+	repo.Git("config", "--add", "wt.hook", "touch config-hook-marker.txt")
 
 	// Create worktree
 	out, err := runGitWt(t, binPath, repo.Root, "hook-config-test")
@@ -1284,7 +1284,7 @@ func TestE2E_HookNotRunOnExistingWorktree(t *testing.T) {
 	}
 }
 
-// TestE2E_HookFlagOverridesConfig tests that --hook flag overrides wt.hooks config.
+// TestE2E_HookFlagOverridesConfig tests that --hook flag overrides wt.hook config.
 func TestE2E_HookFlagOverridesConfig(t *testing.T) {
 	binPath := buildBinary(t)
 
@@ -1293,7 +1293,7 @@ func TestE2E_HookFlagOverridesConfig(t *testing.T) {
 	repo.Commit("initial commit")
 
 	// Set hook in config
-	repo.Git("config", "--add", "wt.hooks", "touch config-marker.txt")
+	repo.Git("config", "--add", "wt.hook", "touch config-marker.txt")
 
 	// Create worktree with --hook flag (should override config)
 	out, err := runGitWt(t, binPath, repo.Root, "--hook", "touch flag-marker.txt", "hook-override-test")

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -16,7 +16,7 @@ const (
 	configKeyCopyUntracked = "wt.copyuntracked"
 	configKeyCopyModified  = "wt.copymodified"
 	configKeyNoCopy        = "wt.nocopy"
-	configKeyHooks         = "wt.hooks"
+	configKeyHook         = "wt.hook"
 )
 
 // Config holds all wt configuration values.
@@ -143,7 +143,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	cfg.NoCopy = noCopy
 
 	// Hooks
-	hooks, err := GitConfig(ctx, configKeyHooks)
+	hooks, err := GitConfig(ctx, configKeyHook)
 	if err != nil {
 		return cfg, err
 	}


### PR DESCRIPTION
This pull request standardizes the configuration key for worktree hooks from `wt.hooks` to `wt.hook` throughout the codebase, documentation, and tests. This change ensures consistency and avoids confusion when setting up commands to run after creating a new worktree.

Configuration key update:

* Renamed the configuration key from `wt.hooks` to `wt.hook` in `internal/git/config.go`, including the constant definition and its usage in the `LoadConfig` function. [[1]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bL19-R19) [[2]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bL146-R146)

Documentation update:

* Updated all references from `wt.hooks` to `wt.hook` in `README.md` and the configuration help text in `cmd/root.go`, including example commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R157) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL106-R111)
