### PR TITLE
fix: enable flag completion in shell integration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -98,7 +98,6 @@ _git-wt() {
     done < <(command git-wt __complete "${words[CURRENT]}" 2>/dev/null)
     _describe 'git-wt' completions
 }
-compdef _git-wt git-wt
 
 # Hook into git completion for 'git wt'
 _git-wt-wrapper() {
@@ -112,7 +111,12 @@ _git-wt-wrapper() {
         _git
     fi
 }
-compdef _git-wt-wrapper git
+
+# Register completions if compdef is available
+if (( $+functions[compdef] )); then
+    compdef _git-wt git-wt
+    compdef _git-wt-wrapper git
+fi
 `
 
 // Fish hooks.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -410,7 +410,7 @@ func TestE2E_InitScript(t *testing.T) {
 		},
 		{
 			shell:    "zsh",
-			contains: []string{"# git-wt shell hook for zsh", "_git_wt()"},
+			contains: []string{"# git-wt shell hook for zsh", "_git-wt()"},
 		},
 		{
 			shell:    "fish",


### PR DESCRIPTION
This pull request enhances the shell completion functionality for the `git-wt` command across Bash, Zsh, and Fish shells, and adds comprehensive end-to-end tests for the completion system. The changes improve the user experience by providing more informative and accurate completions, including descriptions for flags, and ensure correctness through automated testing.

**Shell completion improvements:**

* **Zsh completion now includes descriptions for flags and branches, and integrates more smoothly with both `git-wt` and `git wt` invocations.** The completion function parses tab-separated output to show descriptions when available, and hooks into the main `git` completion for subcommands.
* **Bash and Fish completions have been updated to provide more accurate suggestions based on the current input.** For Bash, completions are filtered and formatted to only include the relevant field. For Fish, the completion logic now handles partial input and supports completions beyond just branches. [[1]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL50-R50) [[2]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL129-R160)

**Testing enhancements:**

* **A new end-to-end test suite (`TestE2E_Complete`) verifies the behavior of the `__complete` command.** The tests check that completions return the correct branches, filter appropriately on partial input, and provide flags with descriptions in the expected format. This ensures the reliability and correctness of the completion feature.