### PR TITLE
feat: add descriptions to branch/worktree completion

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -195,9 +195,12 @@ $scriptBlock = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $tokens = $commandAst.ToString() -split '\s+'
     if ($tokens.Count -ge 2 -and $tokens[1] -eq "wt") {
-        $branches = & git-wt.exe __complete $wordToComplete 2>$null | Where-Object { $_ -notmatch '^:' }
-        $branches | ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        $completions = & git-wt.exe __complete $wordToComplete 2>$null | Where-Object { $_ -notmatch '^:' }
+        $completions | ForEach-Object {
+            $parts = $_ -split [char]9, 2
+            $completion = $parts[0]
+            $tooltip = if ($parts.Count -gt 1) { $parts[1] } else { $parts[0] }
+            [System.Management.Automation.CompletionResult]::new($completion, $completion, 'ParameterValue', $tooltip)
         }
     }
 }

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -111,6 +111,19 @@ func ListBranches(ctx context.Context) ([]string, error) {
 	return branches, nil
 }
 
+// BranchCommitMessage returns the first line of the latest commit message for a branch.
+func BranchCommitMessage(ctx context.Context, branch string) (string, error) {
+	cmd, err := gitCommand(ctx, "log", "-1", "--format=%s", branch, "--")
+	if err != nil {
+		return "", err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // DefaultBranch returns the default branch name (e.g., main, master).
 func DefaultBranch(ctx context.Context) (string, error) {
 	// Try to get from remote origin


### PR DESCRIPTION
This pull request enhances the shell completion feature for branches and worktrees by adding descriptive tooltips and commit messages to the completion results. It also updates the PowerShell completion script to display these tooltips and introduces tests to verify the new behavior.

**Shell completion improvements:**

* Branch and worktree completions now include descriptive tooltips, such as `[branch]`, `[branch: worktree=dir]`, or `[worktree: branch=name]`, and show the latest commit message (truncated) for each entry. (`cmd/root.go`)
* Added a helper function `BranchCommitMessage` to retrieve the latest commit message for a branch. (`internal/git/branch.go`)
* Updated the PowerShell completion script to display the tooltip for each completion entry. (`cmd/init.go`)

**Testing improvements:**

* Added end-to-end tests to verify that branch and worktree completions include the correct descriptions and commit messages. (`e2e_test.go`)