### PR TITLE
fix: rename `--no-switch-directory` flag to `--nocd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ Invoke-Expression (git wt --init powershell | Out-String)
 > [!IMPORTANT]
 > The shell integration creates a `git()` wrapper function to enable automatic directory switching with `git wt <branch>`. This wrapper intercepts only `git wt <branch>` commands and passes all other git commands through unchanged. If you have other tools or customizations that also wrap the `git` command, there may be conflicts.
 
-If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--no-switch-directory` option:
+If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--nocd` option:
 
 ``` zsh
-eval "$(git wt --init zsh --no-switch-directory)"
+eval "$(git wt --init zsh --nocd)"
 ```
 
-You can also use `--no-switch-directory` with `git wt <branch>` to create/switch to a worktree without changing the current directory:
+You can also use `--nocd` with `git wt <branch>` to create/switch to a worktree without changing the current directory:
 
 ``` console
-$ git wt --no-switch-directory feature-branch
+$ git wt --nocd feature-branch
 /path/to/worktree/feature-branch  # prints path but stays in current directory
 ```
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,7 +15,7 @@ git() {
         local no_switch=false
         local args=()
         for arg in "$@"; do
-            if [[ "$arg" == "--no-switch-directory" ]]; then
+            if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
                 no_switch=true
             fi
             args+=("$arg")
@@ -60,7 +60,7 @@ git() {
         local no_switch=false
         local args=()
         for arg in "$@"; do
-            if [[ "$arg" == "--no-switch-directory" ]]; then
+            if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
                 no_switch=true
             fi
             args+=("$arg")
@@ -126,7 +126,7 @@ function git --wraps git
     if test "$argv[1]" = "wt"
         set -l no_switch false
         for arg in $argv[2..]
-            if test "$arg" = "--no-switch-directory"
+            if test "$arg" = "--nocd" -o "$arg" = "--no-switch-directory"
                 set no_switch true
                 break
             end
@@ -170,7 +170,7 @@ const powershellGitWrapper = `
 function Invoke-Git {
     if ($args[0] -eq "wt") {
         $wtArgs = $args[1..($args.Length-1)]
-        $noSwitch = $wtArgs -contains "--no-switch-directory"
+        $noSwitch = ($wtArgs -contains "--nocd") -or ($wtArgs -contains "--no-switch-directory")
         $result = & git.exe wt @wtArgs 2>&1
         if ($LASTEXITCODE -eq 0 -and (Test-Path $result -PathType Container)) {
             if ($noSwitch) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,10 +36,10 @@ import (
 )
 
 var (
-	deleteFlag        bool
-	forceDeleteFlag   bool
-	initShell         string
-	noSwitchDirectory bool
+	deleteFlag      bool
+	forceDeleteFlag bool
+	initShell       string
+	nocd            bool
 	// Config override flags.
 	basedirFlag       string
 	copyignoredFlag   bool
@@ -126,7 +126,11 @@ func init() {
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
-	rootCmd.Flags().BoolVar(&noSwitchDirectory, "no-switch-directory", false, "Do not switch directory after creating/switching worktree (also disables git() wrapper when used with --init)")
+	rootCmd.Flags().BoolVar(&nocd, "nocd", false, "Do not change directory after creating/switching worktree (also disables git() wrapper when used with --init)")
+	rootCmd.Flags().BoolVar(&nocd, "no-switch-directory", false, "")
+	if err := rootCmd.Flags().MarkDeprecated("no-switch-directory", "use --nocd instead"); err != nil {
+		panic(err) //nostyle:dontpanic
+	}
 	// Config override flags.
 	rootCmd.Flags().StringVar(&basedirFlag, "basedir", "", "Override wt.basedir config (worktree base directory)")
 	rootCmd.Flags().BoolVar(&copyignoredFlag, "copyignored", false, "Override wt.copyignored config (copy .gitignore'd files)")
@@ -141,7 +145,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	// Handle init flag
 	if initShell != "" {
-		return runInit(initShell, noSwitchDirectory)
+		return runInit(initShell, nocd)
 	}
 
 	// No arguments: list worktrees

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -439,17 +439,17 @@ func TestE2E_InitScript(t *testing.T) {
 	}
 }
 
-func TestE2E_InitScript_NoSwitchDirectory(t *testing.T) {
+func TestE2E_InitScript_Nocd(t *testing.T) {
 	binPath := buildBinary(t)
 
-	out, err := runGitWt(t, binPath, t.TempDir(), "--init", "bash", "--no-switch-directory")
+	out, err := runGitWt(t, binPath, t.TempDir(), "--init", "bash", "--nocd")
 	if err != nil {
-		t.Fatalf("git-wt --init bash --no-switch-directory failed: %v\noutput: %s", err, out)
+		t.Fatalf("git-wt --init bash --nocd failed: %v\noutput: %s", err, out)
 	}
 
 	// Should not contain the git wrapper function
 	if strings.Contains(out, "git() {") {
-		t.Error("output should not contain git wrapper when --no-switch-directory is used")
+		t.Error("output should not contain git wrapper when --nocd is used")
 	}
 
 	// Should still contain completion
@@ -1090,9 +1090,9 @@ func TestE2E_FlagOverridesConfig(t *testing.T) {
 	}
 }
 
-// TestE2E_ShellIntegration_NoSwitchDirectory tests that --no-switch-directory flag
+// TestE2E_ShellIntegration_Nocd tests that --nocd flag
 // prevents cd when used with git wt <branch> via shell integration.
-func TestE2E_ShellIntegration_NoSwitchDirectory(t *testing.T) {
+func TestE2E_ShellIntegration_Nocd(t *testing.T) {
 	binPath := buildBinary(t)
 
 	tests := []struct {
@@ -1110,8 +1110,8 @@ cd %q
 export PATH="%s:$PATH"
 eval "$(git wt --init bash)"
 
-# Test: git wt --no-switch-directory <branch> should NOT cd to the worktree
-git wt --no-switch-directory no-switch-bash-test
+# Test: git wt --nocd <branch> should NOT cd to the worktree
+git wt --nocd nocd-bash-test
 pwd
 `, repoRoot, pathDir)
 			},
@@ -1126,8 +1126,8 @@ cd %q
 export PATH="%s:$PATH"
 eval "$(git wt --init zsh)"
 
-# Test: git wt --no-switch-directory <branch> should NOT cd to the worktree
-git wt --no-switch-directory no-switch-zsh-test
+# Test: git wt --nocd <branch> should NOT cd to the worktree
+git wt --nocd nocd-zsh-test
 pwd
 `, repoRoot, pathDir)
 			},
@@ -1141,8 +1141,8 @@ cd %q
 set -x PATH %s $PATH
 git wt --init fish | source
 
-# Test: git wt --no-switch-directory <branch> should NOT cd to the worktree
-git wt --no-switch-directory no-switch-fish-test
+# Test: git wt --nocd <branch> should NOT cd to the worktree
+git wt --nocd nocd-fish-test
 pwd
 `, repoRoot, pathDir)
 			},
@@ -1163,7 +1163,7 @@ pwd
 			cmd := exec.Command(tt.shell, "-c", script) //#nosec G204
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				t.Fatalf("%s shell integration with --no-switch-directory failed: %v\noutput: %s", tt.shell, err, out)
+				t.Fatalf("%s shell integration with --nocd failed: %v\noutput: %s", tt.shell, err, out)
 			}
 
 			output := strings.TrimSpace(string(out))
@@ -1171,8 +1171,8 @@ pwd
 			pwd := lines[len(lines)-1]
 
 			// pwd should be the original repo root, NOT the new worktree
-			if strings.Contains(pwd, "no-switch-"+tt.name+"-test") {
-				t.Errorf("pwd should NOT contain worktree path when --no-switch-directory is used, got: %s", pwd)
+			if strings.Contains(pwd, "nocd-"+tt.name+"-test") {
+				t.Errorf("pwd should NOT contain worktree path when --nocd is used, got: %s", pwd)
 			}
 			if pwd != repo.Root {
 				t.Errorf("pwd should be original repo root %q, got: %s", repo.Root, pwd)
@@ -1438,7 +1438,7 @@ func TestE2E_Complete(t *testing.T) {
 			"--copymodified",
 			"--hook",
 			"--nocopy",
-			"--no-switch-directory",
+			"--nocd",
 			"-d",
 			"-D",
 		}


### PR DESCRIPTION
This pull request standardizes and simplifies the flag used to prevent automatic directory switching when creating or switching worktrees. The new `--nocd` flag replaces the older `--no-switch-directory` flag, which is now deprecated but still supported for backward compatibility. The documentation, shell integration scripts, code, and tests have all been updated to reflect this change.

**Flag Standardization and Deprecation:**

* Introduced the `--nocd` flag as the preferred way to prevent directory switching after worktree operations, and deprecated the `--no-switch-directory` flag, which is still accepted for backward compatibility (`cmd/root.go`). [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL42-R42) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL129-R131)
* Updated flag handling in shell integration scripts for bash, zsh, fish, and PowerShell to recognize both `--nocd` and `--no-switch-directory` for compatibility (`cmd/init.go`). [[1]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL18-R18) [[2]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL63-R63) [[3]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL129-R129) [[4]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL173-R173)

**Documentation Updates:**

* Revised the `README.md` to reference `--nocd` instead of `--no-switch-directory` in all usage examples and documentation.

**Code and Test Updates:**

* Updated command-line parsing and function calls to use the new `nocd` flag variable, ensuring consistent behavior throughout the codebase (`cmd/root.go`).
* Renamed and updated all relevant tests to use `--nocd` instead of `--no-switch-directory`, including test names, comments, and assertions (`e2e_test.go`). [[1]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL442-R452) [[2]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1093-R1095) [[3]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1113-R1114) [[4]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1129-R1130) [[5]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1144-R1145) [[6]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1166-R1175) [[7]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bL1441-R1441)