### PR TITLE
feat: add `wt.nocd` config option to disable directory switching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,15 @@ $ git wt --hook "npm install" feature-branch
 > [!NOTE]
 > - Hooks only run when **creating** a new worktree, not when switching to an existing one.
 > - If a hook fails, execution stops immediately and `git wt` exits with an error (shell integration will not `cd` to the worktree).
+
+#### `wt.nocd` / `--nocd`
+
+Do not change directory to the worktree. Only print the worktree path. When set to true, also disables `git()` wrapper when used with `--init`.
+
+``` console
+$ git config wt.nocd true
+# or use for a single invocation
+$ git wt --nocd feature-branch
+```
+
+Default: `false`

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -17,6 +17,7 @@ const (
 	configKeyCopyModified  = "wt.copymodified"
 	configKeyNoCopy        = "wt.nocopy"
 	configKeyHook          = "wt.hook"
+	configKeyNoCd          = "wt.nocd"
 )
 
 // Config holds all wt configuration values.
@@ -27,6 +28,7 @@ type Config struct {
 	CopyModified  bool
 	NoCopy        []string
 	Hooks         []string
+	NoCd          bool
 }
 
 // GitConfig retrieves all git config values for a key.
@@ -148,6 +150,13 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return cfg, err
 	}
 	cfg.Hooks = hooks
+
+	// NoCd
+	val, err = GitConfig(ctx, configKeyNoCd)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.NoCd = len(val) > 0 && val[len(val)-1] == "true"
 
 	return cfg, nil
 }

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -160,6 +160,21 @@ func TestLoadConfig(t *testing.T) {
 	if cfg.CopyModified {
 		t.Errorf("LoadConfig().CopyModified default = %v, want false", cfg.CopyModified) //nostyle:errorstrings
 	}
+	if cfg.NoCd {
+		t.Errorf("LoadConfig().NoCd default = %v, want false", cfg.NoCd) //nostyle:errorstrings
+	}
+
+	// Test NoCd setting
+	repo.Git("config", "wt.nocd", "true")
+
+	cfg, err = LoadConfig(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.NoCd {
+		t.Errorf("LoadConfig().NoCd = %v, want true", cfg.NoCd) //nostyle:errorstrings
+	}
 }
 
 func TestExpandPath(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for a new `wt.nocd` configuration option and `--nocd` flag, allowing users to prevent automatic directory changes when creating or switching to a worktree. The implementation ensures that this option is respected both via command-line flags and git config, updates documentation and help text, and introduces comprehensive tests for the new behavior.

**New configuration/flag support:**

* Added a `wt.nocd` git config option and a `--nocd` command-line flag to prevent changing directory to the worktree after creation or switch. When enabled, this also disables the `git()` shell wrapper when used with `--init`. [[1]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR20) [[2]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR31) [[3]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR154-R160) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL111-R117) [[5]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL129-R135) [[6]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR152-R163)

**Documentation updates:**

* Updated `README.md` and CLI help text to document the new `wt.nocd` config and `--nocd` flag, including usage examples and default behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R176) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL111-R117) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL129-R135)

**Testing improvements:**

* Added end-to-end and unit tests to verify that the `wt.nocd` config and `--nocd` flag prevent directory changes and disable the `git()` wrapper as expected, across multiple shells and scenarios. [[1]](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bR1184-R1301) [[2]](diffhunk://#diff-6b1e098ad1b49316bd13bce97250b63916a775b9d0cd3dda2b8ae4a38bfc44ddR163-R177)