### PR TITLE
fix: shell wrappers now respect `wt.nocd` config setting

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,6 +13,10 @@ git() {
     if [[ "$1" == "wt" ]]; then
         shift
         local no_switch=false
+        # Check wt.nocd config
+        if [[ "$(command git config --get wt.nocd 2>/dev/null)" == "true" ]]; then
+            no_switch=true
+        fi
         local args=()
         for arg in "$@"; do
             if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
@@ -58,6 +62,10 @@ git() {
     if [[ "$1" == "wt" ]]; then
         shift
         local no_switch=false
+        # Check wt.nocd config
+        if [[ "$(command git config --get wt.nocd 2>/dev/null)" == "true" ]]; then
+            no_switch=true
+        fi
         local args=()
         for arg in "$@"; do
             if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
@@ -125,6 +133,10 @@ const fishGitWrapper = `
 function git --wraps git
     if test "$argv[1]" = "wt"
         set -l no_switch false
+        # Check wt.nocd config
+        if test "$(command git config --get wt.nocd 2>/dev/null)" = "true"
+            set no_switch true
+        end
         for arg in $argv[2..]
             if test "$arg" = "--nocd" -o "$arg" = "--no-switch-directory"
                 set no_switch true
@@ -171,6 +183,13 @@ function Invoke-Git {
     if ($args[0] -eq "wt") {
         $wtArgs = $args[1..($args.Length-1)]
         $noSwitch = ($wtArgs -contains "--nocd") -or ($wtArgs -contains "--no-switch-directory")
+        # Check wt.nocd config
+        if (-not $noSwitch) {
+            $nocdConfig = & git.exe config --get wt.nocd 2>$null
+            if ($nocdConfig -eq "true") {
+                $noSwitch = $true
+            }
+        }
         $result = & git.exe wt @wtArgs 2>&1
         if ($LASTEXITCODE -eq 0 -and (Test-Path $result -PathType Container)) {
             if ($noSwitch) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,18 +149,9 @@ func init() {
 func runRoot(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	// Load config for nocd default
-	cfg, err := git.LoadConfig(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	// Apply nocd from config if flag not explicitly set
-	effectiveNocd := nocd || cfg.NoCd
-
-	// Handle init flag
+	// Handle init flag (only respects --nocd flag, not wt.nocd config)
 	if initShell != "" {
-		return runInit(initShell, effectiveNocd)
+		return runInit(initShell, nocd)
 	}
 
 	// No arguments: list worktrees

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1274,8 +1274,9 @@ pwd
 	}
 }
 
-// TestE2E_NocdConfigWithInitNocd tests that --init with wt.nocd config also disables git() wrapper.
-func TestE2E_NocdConfigWithInitNocd(t *testing.T) {
+// TestE2E_NocdConfigWithInit tests that --init ignores wt.nocd config and always outputs git() wrapper.
+// The wt.nocd config only affects cd behavior at runtime, not the init output.
+func TestE2E_NocdConfigWithInit(t *testing.T) {
 	binPath := buildBinary(t)
 
 	repo := testutil.NewTestRepo(t)
@@ -1293,9 +1294,10 @@ func TestE2E_NocdConfigWithInitNocd(t *testing.T) {
 		t.Fatalf("git-wt --init bash failed: %v\noutput: %s", err, out)
 	}
 
-	// With wt.nocd=true config, output should not contain git wrapper
-	if strings.Contains(out, "git() {") {
-		t.Error("output should not contain git wrapper when wt.nocd=true config is set")
+	// With wt.nocd=true config, --init should still output git wrapper
+	// (wt.nocd only affects runtime cd behavior, not init output)
+	if !strings.Contains(out, "git() {") {
+		t.Error("output should contain git wrapper even when wt.nocd=true config is set")
 	}
 }
 


### PR DESCRIPTION
The shell wrapper functions (bash, zsh, fish, powershell) only checked for the `--nocd` flag but ignored the wt.nocd git config setting. This caused `git wt <branch>` to cd into the worktree even when `wt.nocd` was set to true.

Added `git config --get wt.nocd` check to all shell wrappers.

Also changed `--init` to ignore `wt.nocd` config (only respects `--nocd` flag).