### PR TITLE
fix: use string match instead of test in fish shell hook to avoid errors with short options

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -138,7 +138,7 @@ function git --wraps git
             set no_switch true
         end
         for arg in $argv[2..]
-            if test "$arg" = "--nocd" -o "$arg" = "--no-switch-directory"
+            if string match -q -- "--nocd" "$arg"; or string match -q -- "--no-switch-directory" "$arg"
                 set no_switch true
                 break
             end


### PR DESCRIPTION
When using short options like `-h` or `-d` in fish shell, the `test` command was interpreting the argument as a test operator, causing errors like: "test: Expected a combining operator like '-a' at index 3"

Replace `test "$arg" = "..."` with `string match -q -- "..." "$arg"` to properly handle arguments that start with hyphens.

Fixes #48