### PR TITLE
feat: add wt.copy to always copy specific gitignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ Supported patterns (same as `.gitignore`):
 - `**/temp`: match in any directory
 - `/config.local`: relative to git root
 
+#### `wt.copy` / `--copy`
+
+Always copy files matching patterns, even if they are gitignored. Uses `.gitignore` syntax.
+
+``` console
+$ git config --add wt.copy "*.code-workspace"
+$ git config --add wt.copy ".vscode/"
+# or override for a single invocation (multiple patterns supported)
+$ git wt --copy "*.code-workspace" --copy ".vscode/" feature-branch
+```
+
+This is useful when you want to copy specific IDE files (like VS Code workspace files) without enabling `wt.copyignored` for all gitignored files.
+
+> [!NOTE]
+> If the same file matches both `wt.copy` and `wt.nocopy`, `wt.nocopy` takes precedence.
+
 #### `wt.hook` / `--hook`
 
 Commands to run after creating a new worktree. Hooks run in the new worktree directory.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var (
 	copyuntrackedFlag bool
 	copymodifiedFlag  bool
 	nocopyFlag        []string
+	copyFlag          []string
 	hookFlag          []string
 )
 
@@ -103,6 +104,13 @@ Configuration:
     Example: git config --add wt.nocopy "*.log"
              git config --add wt.nocopy "vendor/"
 
+  wt.copy (--copy)
+    Patterns for files to always copy, even if gitignored (gitignore syntax).
+    Can be specified multiple times. Useful for copying specific IDE files.
+    Note: If the same file matches both wt.copy and wt.nocopy, wt.nocopy takes precedence.
+    Example: git config --add wt.copy "*.code-workspace"
+             git config --add wt.copy ".vscode/"
+
   wt.hook (--hook)
     Commands to run after creating a new worktree.
     Can be specified multiple times. Hooks run in the new worktree directory.
@@ -143,6 +151,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&copyuntrackedFlag, "copyuntracked", false, "Override wt.copyuntracked config (copy untracked files)")
 	rootCmd.Flags().BoolVar(&copymodifiedFlag, "copymodified", false, "Override wt.copymodified config (copy modified files)")
 	rootCmd.Flags().StringArrayVar(&nocopyFlag, "nocopy", nil, "Exclude files matching pattern from copying (can be specified multiple times)")
+	rootCmd.Flags().StringArrayVar(&copyFlag, "copy", nil, "Always copy files matching pattern (can be specified multiple times)")
 	rootCmd.Flags().StringArrayVar(&hookFlag, "hook", nil, "Run command after creating new worktree (can be specified multiple times)")
 }
 
@@ -196,6 +205,9 @@ func loadConfig(ctx context.Context, cmd *cobra.Command) (git.Config, error) {
 	}
 	if cmd.Flags().Changed("nocopy") {
 		cfg.NoCopy = nocopyFlag
+	}
+	if cmd.Flags().Changed("copy") {
+		cfg.Copy = copyFlag
 	}
 	if cmd.Flags().Changed("hook") {
 		cfg.Hooks = hookFlag
@@ -432,6 +444,7 @@ func handleWorktrees(ctx context.Context, cmd *cobra.Command, branches []string)
 		CopyUntracked: cfg.CopyUntracked,
 		CopyModified:  cfg.CopyModified,
 		NoCopy:        cfg.NoCopy,
+		Copy:          cfg.Copy,
 	}
 
 	for _, branch := range branches {

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -16,6 +16,7 @@ const (
 	configKeyCopyUntracked = "wt.copyuntracked"
 	configKeyCopyModified  = "wt.copymodified"
 	configKeyNoCopy        = "wt.nocopy"
+	configKeyCopy          = "wt.copy"
 	configKeyHook          = "wt.hook"
 	configKeyNoCd          = "wt.nocd"
 )
@@ -27,6 +28,7 @@ type Config struct {
 	CopyUntracked bool
 	CopyModified  bool
 	NoCopy        []string
+	Copy          []string
 	Hooks         []string
 	NoCd          bool
 }
@@ -143,6 +145,13 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return cfg, err
 	}
 	cfg.NoCopy = noCopy
+
+	// Copy
+	copyPatterns, err := GitConfig(ctx, configKeyCopy)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Copy = copyPatterns
 
 	// Hooks
 	hooks, err := GitConfig(ctx, configKeyHook)


### PR DESCRIPTION
Add `wt.copy` config and `--copy` flag to specify patterns for files that should always be copied, even if gitignored.

Note: wt.nocopy takes precedence over wt.copy.

Closes #49