### PR TITLE
feat: support start-point argument for worktree creation

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -124,6 +124,27 @@ func BranchCommitMessage(ctx context.Context, branch string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// ListRemoteBranches returns a list of all remote branch names (e.g., origin/main).
+func ListRemoteBranches(ctx context.Context) ([]string, error) {
+	cmd, err := gitCommand(ctx, "branch", "-r", "--format=%(refname:short)")
+	if err != nil {
+		return nil, err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var branches []string
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for _, line := range lines {
+		if line != "" && !strings.HasSuffix(line, "/HEAD") {
+			branches = append(branches, line)
+		}
+	}
+	return branches, nil
+}
+
 // DefaultBranch returns the default branch name (e.g., main, master).
 func DefaultBranch(ctx context.Context) (string, error) {
 	// Try to get from remote origin

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -194,7 +194,8 @@ func AddWorktree(ctx context.Context, path, branch string, copyOpts CopyOptions)
 }
 
 // AddWorktreeWithNewBranch creates a new worktree with a new branch.
-func AddWorktreeWithNewBranch(ctx context.Context, path, branch string, copyOpts CopyOptions) error {
+// If startPoint is specified, the new branch will be created from that commit/branch.
+func AddWorktreeWithNewBranch(ctx context.Context, path, branch, startPoint string, copyOpts CopyOptions) error {
 	// Get source root before creating worktree
 	srcRoot, err := RepoRoot(ctx)
 	if err != nil {
@@ -207,7 +208,13 @@ func AddWorktreeWithNewBranch(ctx context.Context, path, branch string, copyOpts
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
-	cmd, err := gitCommand(ctx, "worktree", "add", "-b", branch, path)
+	// Build command arguments
+	args := []string{"worktree", "add", "-b", branch, path}
+	if startPoint != "" {
+		args = append(args, startPoint)
+	}
+
+	cmd, err := gitCommand(ctx, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -175,7 +175,7 @@ func TestAddWorktreeWithNewBranch(t *testing.T) {
 	defer restore()
 
 	wtPath := filepath.Join(repo.ParentDir(), "worktree-new")
-	err := AddWorktreeWithNewBranch(t.Context(), wtPath, "new-branch", CopyOptions{})
+	err := AddWorktreeWithNewBranch(t.Context(), wtPath, "new-branch", "", CopyOptions{})
 	if err != nil {
 		t.Fatalf("AddWorktreeWithNewBranch failed: %v", err)
 	}


### PR DESCRIPTION
`git wt <branch|worktree> [<start-point>]` now works like git branch. This allows creating worktrees from specific branches like `origin/main`.

**BREAKING:** Multiple worktree creation without `-d/-D` is no longer supported.

Closes #52