### PR TITLE
fix: invoke cd regardless of branch deletion result

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -502,12 +502,18 @@ func deleteWorktrees(ctx context.Context, branches []string, force bool) error {
 			// If we deleted the current worktree, run git from mainRoot since cwd no longer exists
 			if branchExists {
 				if err := git.DeleteBranchInDir(ctx, wt.Branch, force, mainRoot); err != nil {
-					return fmt.Errorf("failed to delete branch (use -D to force): %w", err)
-				}
-				if wtDir == wt.Branch {
-					fmt.Printf("Deleted worktree and branch %q\n", wt.Branch)
+					// Treat as non-fatal since worktree removal succeeded
+					if wtDir == wt.Branch {
+						fmt.Printf("Deleted worktree, but failed to delete branch %q (use -D to force)\n", wt.Branch)
+					} else {
+						fmt.Printf("Deleted worktree %q, but failed to delete branch %q (use -D to force)\n", wtDir, wt.Branch)
+					}
 				} else {
-					fmt.Printf("Deleted worktree %q and branch %q\n", wtDir, wt.Branch)
+					if wtDir == wt.Branch {
+						fmt.Printf("Deleted worktree and branch %q\n", wt.Branch)
+					} else {
+						fmt.Printf("Deleted worktree %q and branch %q\n", wtDir, wt.Branch)
+					}
 				}
 			} else {
 				fmt.Printf("Deleted worktree %q (branch %q did not exist locally)\n", wtDir, wt.Branch)


### PR DESCRIPTION
# Summary

#59 introduced the automatic change directory behavior, but it doesn't work if
the branch contains unmerged changes. We will be left on deleted directory
after git wt -d.

# Current behavior

Precondition: the branch 'cd-anyway' contains unmerged changes.

```
yoichi@Mac git-wt % git wt cd-anyway
Preparing worktree (checking out 'cd-anyway')
HEAD is now at 8c4a5af fix: invoke cd regardless of branch deletion result
yoichi@Mac cd-anyway % git wt -d cd-anyway
error: the branch 'cd-anyway' is not fully merged
hint: If you are sure you want to delete it, run 'git branch -D cd-anyway'
hint: Disable this message with "git config set advice.forceDeleteBranch false"
Error: failed to delete branch (use -D to force): exit status 1

yoichi@Mac cd-anyway % pwd
/Users/yoichi/ghq/github.com/k1LoW/git-wt-wt/cd-anyway
yoichi@Mac cd-anyway % ls ..
yoichi@Mac cd-anyway %
```

# Fixed behavior

```
yoichi@Mac git-wt % git wt cd-anyway
Preparing worktree (checking out 'cd-anyway')
HEAD is now at 8c4a5af fix: invoke cd regardless of branch deletion result
yoichi@Mac cd-anyway % git wt -d cd-anyway
error: the branch 'cd-anyway' is not fully merged
hint: If you are sure you want to delete it, run 'git branch -D cd-anyway'
hint: Disable this message with "git config set advice.forceDeleteBranch false"
Deleted worktree, but failed to delete branch "cd-anyway" (use -D to force)
yoichi@Mac git-wt % pwd
/Users/yoichi/ghq/github.com/k1LoW/git-wt
yoichi@Mac git-wt %
```

Note: we can restore the worktree by `git wt cd-anyway` again.