### PR TITLE
fix: use an invalid branch name as the detached HEAD marker

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -275,7 +275,7 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 			}
 
 			// Add branch name with [branch: worktree=dir] or [worktree: branch=name] marker
-			if wt.Branch != "" && wt.Branch != "(detached)" {
+			if wt.Branch != "" && wt.Branch != "[detached]" {
 				if _, exists := seen[wt.Branch]; !exists {
 					seen[wt.Branch] = struct{}{}
 					worktreeNames[wt.Branch] = struct{}{}
@@ -306,7 +306,7 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 					seen[wtDirName] = struct{}{}
 					worktreeNames[wtDirName] = struct{}{}
 					branchInfo := wt.Branch
-					if branchInfo == "" || branchInfo == "(detached)" {
+					if branchInfo == "" || branchInfo == "[detached]" {
 						branchInfo = "detached"
 					}
 					var desc string

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -60,7 +60,8 @@ func ListWorktrees(ctx context.Context) ([]Worktree, error) {
 		case line == "bare":
 			current.Bare = true
 		case line == "detached":
-			current.Branch = "(detached)"
+			// Use an invalid branch name as the detached HEAD marker
+			current.Branch = "[detached]"
 		}
 	}
 
@@ -110,7 +111,7 @@ func FindWorktreeByBranchOrDir(ctx context.Context, query string) (*Worktree, er
 
 	// First, try to find by branch name
 	for _, wt := range worktrees {
-		if wt.Branch == query {
+		if wt.Branch != "[detached]" && wt.Branch == query {
 			return &wt, nil
 		}
 	}


### PR DESCRIPTION
# Summary

use an invalid branch name as the detached HEAD marker to 

* avoid deleting irrelevant branches with git wt -d
* avoid matching with the detached HEAD marker on git wt -d

# Current behavior

Since current detached HEAD marker "(detached)" is an valid branch name,
git wt -d may delete unrelated branch.

```
yoichi@Mac git-wt % git wt
  PATH                                       BRANCH  HEAD
* /Users/yoichi/ghq/github.com/k1LoW/git-wt  main    fc6a05c
yoichi@Mac git-wt % git branch "(detached)" HEAD~
yoichi@Mac git-wt % git rev-parse "(detached)"
6e14beadfbf5dd189698023b19759020d48ff8c6
yoichi@Mac git-wt % git wt HEAD
Preparing worktree (detached HEAD fc6a05c)
HEAD is now at fc6a05c Merge pull request #66 from k1LoW/dependabot/github_actions/dependencies-5a62337e7f
yoichi@Mac HEAD % git wt
  PATH                                               BRANCH      HEAD
  /Users/yoichi/ghq/github.com/k1LoW/git-wt          main        fc6a05c
* /Users/yoichi/ghq/github.com/k1LoW/git-wt-wt/HEAD  (detached)  fc6a05c
yoichi@Mac HEAD % git wt -d HEAD
Deleted branch (detached) (was 6e14bea).
Deleted worktree "HEAD" and branch "(detached)"
yoichi@Mac git-wt %
```

# Fixed behavior

Use an invalid branch name "[detached]" as the marker, then it won't delete
any branches.

```
yoichi@Mac git-wt % git wt
  PATH                                       BRANCH  HEAD
* /Users/yoichi/ghq/github.com/k1LoW/git-wt  main    fc6a05c
yoichi@Mac git-wt % git branch "[detached]"
fatal: '[detached]' is not a valid branch name
hint: See `man git check-ref-format`
hint: Disable this message with "git config set advice.refSyntax false"
yoichi@Mac git-wt % git branch
* main
yoichi@Mac git-wt % git wt HEAD
Preparing worktree (detached HEAD fc6a05c)
HEAD is now at fc6a05c Merge pull request #66 from k1LoW/dependabot/github_actions/dependencies-5a62337e7f
yoichi@Mac HEAD % git wt
  PATH                                               BRANCH      HEAD
  /Users/yoichi/ghq/github.com/k1LoW/git-wt          main        fc6a05c
* /Users/yoichi/ghq/github.com/k1LoW/git-wt-wt/HEAD  [detached]  fc6a05c
yoichi@Mac HEAD % git wt -d HEAD
Deleted worktree "HEAD" (branch "[detached]" did not exist locally)
yoichi@Mac git-wt %
```

# Note

New marker "[detached]" can used as a worktree name (though it cannot be created with git wt).
git wt -d can handle it nicely.

```
yoichi@Mac git-wt % git wt
  PATH                                       BRANCH  HEAD
* /Users/yoichi/ghq/github.com/k1LoW/git-wt  main    fc6a05c
yoichi@Mac git-wt % git branch test-branch
yoichi@Mac git-wt % git worktree add ../git-wt-wt/\[detached\] test-branch
Preparing worktree (checking out 'test-branch')
HEAD is now at fc6a05c Merge pull request #66 from k1LoW/dependabot/github_actions/dependencies-5a62337e7f
yoichi@Mac git-wt % git wt
  PATH                                                     BRANCH       HEAD
* /Users/yoichi/ghq/github.com/k1LoW/git-wt                main         fc6a05c
  /Users/yoichi/ghq/github.com/k1LoW/git-wt-wt/[detached]  test-branch  fc6a05c
yoichi@Mac git-wt % git wt -d "[detached]"
Deleted branch test-branch (was fc6a05c).
Deleted worktree "[detached]" and branch "test-branch"
yoichi@Mac git-wt % git wt
  PATH                                       BRANCH  HEAD
* /Users/yoichi/ghq/github.com/k1LoW/git-wt  main    fc6a05c
yoichi@Mac git-wt %
```
