### PR TITLE
fix: MainRepoRoot to return proper repo root

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -71,7 +71,7 @@ func RepoRoot(ctx context.Context) (string, error) {
 // MainRepoRoot returns the root directory of the main git repository.
 // Unlike RepoRoot, this returns the main repository root even when called from a worktree.
 func MainRepoRoot(ctx context.Context) (string, error) {
-	cmd, err := gitCommand(ctx, "rev-parse", "--git-common-dir")
+	cmd, err := gitCommand(ctx, "rev-parse", "--path-format=absolute", "--git-common-dir")
 	if err != nil {
 		return "", err
 	}
@@ -80,15 +80,6 @@ func MainRepoRoot(ctx context.Context) (string, error) {
 		return "", err
 	}
 	gitCommonDir := strings.TrimSpace(string(out))
-
-	// If git-common-dir is relative (e.g., ".git"), resolve it from current repo root
-	if !filepath.IsAbs(gitCommonDir) {
-		repoRoot, err := RepoRoot(ctx)
-		if err != nil {
-			return "", err
-		}
-		gitCommonDir = filepath.Join(repoRoot, gitCommonDir)
-	}
 
 	// The main repo root is the parent of the .git directory
 	return filepath.Dir(gitCommonDir), nil

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -86,6 +86,43 @@ func TestRepoRoot(t *testing.T) {
 	}
 }
 
+func TestMainRepoRoot(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	repo.CreateFile("README.md", "# Test")
+	repo.Commit("initial commit")
+
+	// Create a subdirectory
+	repo.CreateFile("subdir/file.txt", "content")
+	repo.Commit("add subdir")
+
+	restore := repo.Chdir()
+	defer restore()
+
+	root, err := MainRepoRoot(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if root != repo.Root {
+		t.Errorf("MainRepoRoot() = %q, want %q", root, repo.Root) //nostyle:errorstrings
+	}
+
+	// Test from subdirectory
+	subdir := filepath.Join(repo.Root, "subdir")
+	if err := os.Chdir(subdir); err != nil {
+		t.Fatalf("failed to chdir to subdir: %v", err)
+	}
+
+	root, err = MainRepoRoot(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error from subdir: %v", err)
+	}
+
+	if root != repo.Root {
+		t.Errorf("MainRepoRoot() from subdir = %q, want %q", root, repo.Root) //nostyle:errorstrings
+	}
+}
+
 func TestRepoName(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")


### PR DESCRIPTION
addresses #69 

## Summary
- Fixes worktree base dir resolution when `git wt` is run from a subdirectory.
- Ensures the main repo root is derived from an absolute git common dir so it doesn’t jump one directory too high.

## Changes
- Use `git rev-parse --path-format=absolute --git-common-dir` and drop the manual relative-path handling.
- `--path-format` flag was introduced https://git-scm.com/docs/git-rev-parse/2.31.0 (2021-03-15)