### PR TITLE
fix: improve default branch detection

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -171,16 +171,19 @@ func DefaultBranch(ctx context.Context) (string, error) {
 		return branch, nil
 	}
 
-	// Fallback: check common default branch names
-	for _, name := range []string{"main", "master"} {
-		exists, err := LocalBranchExists(ctx, name)
-		if err != nil {
-			continue
-		}
-		if exists {
-			return name, nil
-		}
+	// Fallback: check git config init.defaultBranch
+	cmd, err = gitCommand(ctx, "config", "--get", "init.defaultBranch")
+	if err != nil {
+		return "", err
 	}
-
-	return "", nil
+	out, err = cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	configBranch := strings.TrimSpace(string(out))
+	if configBranch == "" {
+		// If init.defaultBranch is not set, use Git's built-in default
+		configBranch = "master"
+	}
+	return configBranch, nil
 }

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -229,11 +229,13 @@ func TestDefaultBranch(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")
 	repo.Commit("initial commit")
+	// Set init.defaultBranch in the test repo
+	repo.Git("config", "init.defaultBranch", "main")
 
 	restore := repo.Chdir()
 	defer restore()
 
-	// Without remote, should fallback to checking main/master
+	// Without remote, should fallback to git config init.defaultBranch
 	branch, err := DefaultBranch(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This pull request updates the logic for determining a repository's default branch in the `internal/git/branch.go` file. Instead of checking for the existence of common branch names like `main` or `master`, the code now consults the `init.defaultBranch` Git configuration, providing more accurate and configurable behavior. The related test has also been updated to reflect this change.

**Default branch determination logic:**

* The `DefaultBranch` function now checks the `init.defaultBranch` Git config to determine the default branch, falling back to `"master"` if not set, instead of scanning for `main` or `master` branches.

**Testing updates:**

* The `TestDefaultBranch` test sets the `init.defaultBranch` config in the test repository and verifies that the `DefaultBranch` function uses this value.