### PR TITLE
feat: normalize branch names like gh pr checkout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,6 +180,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return listWorktrees(ctx)
 	}
 
+	// Normalize branch-like arguments before any git operation.
+	args = normalizeBranchArgs(args)
+
 	// Handle delete flags (multiple arguments allowed)
 	if forceDeleteFlag {
 		// Remove duplicates while preserving order
@@ -655,4 +658,12 @@ func uniqueArgs(args []string) []string {
 		}
 	}
 	return result
+}
+
+func normalizeBranchArgs(args []string) []string {
+	normalized := make([]string, len(args))
+	for i, arg := range args {
+		normalized[i] = git.NormalizeBranchName(arg)
+	}
+	return normalized
 }

--- a/internal/git/ref.go
+++ b/internal/git/ref.go
@@ -1,0 +1,9 @@
+package git
+
+import "strings"
+
+// NormalizeBranchName normalizes branch names for safe git refs and filesystem usage.
+// It treats ":" as a display/input sugar and always replaces it with "/".
+func NormalizeBranchName(name string) string {
+	return strings.ReplaceAll(name, ":", "/")
+}

--- a/internal/git/ref_test.go
+++ b/internal/git/ref_test.go
@@ -1,0 +1,24 @@
+package git
+
+import "testing"
+
+func TestNormalizeBranchName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"preserve slash", "someone/main", "someone/main"},
+		{"replace colon", "someone:main", "someone/main"},
+		{"multiple colons", "a:b:c", "a/b/c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeBranchName(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeBranchName(%q) = %q, want %q", tt.in, got, tt.want) //nostyle:errorstrings
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Background
Creating a worktree fails when a remote-style branch name is given, so normalize the name first.

## Changes
Normalize branch names in `git wt` execution.

## Reproduction / Actual Result
```
$ git wt alice:main
Preparing worktree (new branch 'alice:main')
fatal: 'alice:main' is not a valid branch name
```

## Expected Result
Worktree should be created successfully.
