### PR TITLE
fix: disable Cobra's default completion subcommand to avoid confusion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,6 +148,10 @@ func Execute() {
 }
 
 func init() {
+	// Disable Cobra's default "completion" subcommand.
+	// git-wt uses its own shell integration via --init flag instead.
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")


### PR DESCRIPTION
This pull request disables Cobra's default "completion" subcommand in favor of the tool's own shell integration and adds a corresponding end-to-end test to ensure the correct behavior. The most important changes are:

Shell completion behavior changes:

* Disabled Cobra's default "completion" subcommand by setting `rootCmd.CompletionOptions.DisableDefaultCmd = true` in `cmd/root.go`, ensuring that `git wt` uses its own shell integration via the `--init` flag instead.

Testing:

* Added an end-to-end test in `e2e/basic_test.go` to verify that running `git wt completion` does not show Cobra's default completion help and instead treats "completion" as a branch name or returns an appropriate error.