### PR TITLE
fix: exclude `basedir` from file copying to prevent circular copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ This is useful when you want to copy specific IDE files (like VS Code workspace 
 > [!NOTE]
 > If the same file matches both `wt.copy` and `wt.nocopy`, `wt.nocopy` takes precedence.
 
+> [!NOTE]
+> The worktree base directory (`wt.basedir`) is always excluded from file copying, regardless of copy options. This prevents circular copying when basedir is inside the repository (e.g., `.worktrees/`).
+
 #### `wt.hook` / `--hook`
 
 Commands to run after creating a new worktree. Hooks run in the new worktree directory.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -193,6 +193,9 @@ func AddWorktree(ctx context.Context, path, branch string, copyOpts CopyOptions)
 		return err
 	}
 
+	// Exclude basedir from copy to prevent circular copying
+	copyOpts.ExcludeDirs = append(copyOpts.ExcludeDirs, parentDir)
+
 	// Copy files to new worktree
 	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts); err != nil {
 		return fmt.Errorf("failed to copy files: %w", err)
@@ -236,6 +239,9 @@ func AddWorktreeWithNewBranch(ctx context.Context, path, branch, startPoint stri
 	if err := cmd.Run(); err != nil {
 		return err
 	}
+
+	// Exclude basedir from copy to prevent circular copying
+	copyOpts.ExcludeDirs = append(copyOpts.ExcludeDirs, parentDir)
 
 	// Copy files to new worktree
 	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts); err != nil {


### PR DESCRIPTION
When `basedir` is inside the repository, files in basedir (including existing worktrees) could be copied to new worktrees. This caused circular copying and unnecessary file duplication.