### PR TITLE
fix: check for untracked/modified files before worktree deletion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -514,8 +514,16 @@ func deleteWorktrees(ctx context.Context, branches []string, force bool) error {
 				}
 			}
 
-			// Check for untracked files (only for safe delete)
+			// Check for modified or untracked files (only for safe delete)
 			if !force {
+				modifiedFiles, err := git.ListModifiedFiles(ctx, wt.Path)
+				if err != nil {
+					return fmt.Errorf("failed to check for modified files: %w", err)
+				}
+				if len(modifiedFiles) > 0 {
+					return fmt.Errorf("worktree %q has modified files, use -D to force deletion", branch)
+				}
+
 				untrackedFiles, err := git.ListUntrackedFiles(ctx, wt.Path)
 				if err != nil {
 					return fmt.Errorf("failed to check for untracked files: %w", err)

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -39,7 +39,7 @@ func CopyFilesToWorktree(ctx context.Context, srcRoot, dstRoot string, opts Copy
 	}
 
 	if opts.CopyModified {
-		modified, err := listModifiedFiles(ctx, srcRoot)
+		modified, err := ListModifiedFiles(ctx, srcRoot)
 		if err != nil {
 			return err
 		}
@@ -138,8 +138,8 @@ func ListUntrackedFiles(ctx context.Context, root string) ([]string, error) {
 	return parseFileList(string(out)), nil
 }
 
-// listModifiedFiles returns tracked files with modifications.
-func listModifiedFiles(ctx context.Context, root string) ([]string, error) {
+// ListModifiedFiles returns tracked files with modifications.
+func ListModifiedFiles(ctx context.Context, root string) ([]string, error) {
 	cmd, err := gitCommand(ctx, "ls-files", "--modified")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Pre-check for modified and untracked files before calling `git worktree remove`
- If either exist during safe delete (`-d`), error early with message suggesting `-D`
- Export `ListUntrackedFiles` and `ListModifiedFiles` functions for reuse

## Problem

When users try to delete a worktree with modified or untracked files using `git wt -d`, the underlying `git worktree remove` command fails and suggests using `--force`. However, `git wt` uses `-D` for force deletion, not `--force`. This confuses users.

## Solution

Check for modified and untracked files **before** calling `git worktree remove`. If either exist and we're doing safe delete (`-d`), error early with our own message suggesting `-D`.

Before:
```
$ git wt -d test-wt
fatal: '/home/user/test-wt' contains modified or untracked files, use --force to delete it
Error: failed to remove worktree: exit status 128
```

After:
```
$ git wt -d test-wt
Error: worktree "test-wt" has modified files, use -D to force deletion
```

or:
```
$ git wt -d test-wt
Error: worktree "test-wt" has untracked files, use -D to force deletion
```

## Test plan

- [x] Added e2e test for untracked files scenario
- [x] Added e2e test for modified files scenario
- [x] All existing tests pass
- [x] Manual testing verified correct behavior

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)