### PR TITLE
fix: prevent file completions in fish shell for git wt

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -259,12 +259,25 @@ function __fish_git_wt_completions
     command git-wt __complete $args "$cur" 2>/dev/null | string match -rv '^:'
 end
 
+# Completions for direct git-wt invocation
+function __fish_git_wt_direct_completions
+    set -l cmd (commandline -opc)
+    # Pass all arguments after 'git-wt' to __complete
+    set -l args $cmd[2..]
+    set -l cur (commandline -ct)
+    command git-wt __complete $args "$cur" 2>/dev/null | string match -rv '^:'
+end
+
 function __fish_git_wt_needs_completion
     set -l cmd (commandline -opc)
     test (count $cmd) -ge 2 -a "$cmd[2]" = "wt"
 end
 
-complete -c git -n '__fish_git_wt_needs_completion' -f -a '(__fish_git_wt_completions)'
+# Completions for 'git wt'
+complete -x -c git -n '__fish_git_wt_needs_completion' -a '(__fish_git_wt_completions)'
+
+# Completions for direct 'git-wt' command (needed for fish's custom command handler)
+complete -x -c git-wt -a '(__fish_git_wt_direct_completions)'
 `
 
 // PowerShell hooks.


### PR DESCRIPTION
Fixes #108

Fish completion was showing files and directories in the current directory, in addition to worktrees and branches. Added completions for the `git-wt` command directly to prevent fish's auto-handler from falling back to file completions.

Before:

<img width="1326" height="630" alt="image" src="https://github.com/user-attachments/assets/b223cc54-10e1-4532-811b-fb8182b0c8ea" />

After:

<img width="1257" height="302" alt="image" src="https://github.com/user-attachments/assets/05dfb31f-af2d-454f-9a4d-1145fbaaa51a" />


🤖 Generated with [Claude Code](https://claude.ai/code)