### PR TITLE
feat: add `wt.relative` config and `--relative` flag to append subdirectory to worktree path

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,27 @@ $ git wt --nocd feature-branch
 > - The `--nocd` flag always prevents cd regardless of config value.
 > - Using `--nocd` with `--init` disables the `git()` wrapper entirely (only shell completion is output). The `wt.nocd` config does not affect `--init` output.
 
+#### `wt.relative` / `--relative`
+
+Append the current subdirectory path to the worktree output path. When running from a subdirectory, the output path will include the subdirectory relative to the repository root (like `git diff --relative`).
+
+``` console
+# Enable relative path resolution
+$ git config wt.relative true
+
+# Example: running from repo/some/path/
+$ git wt feature-branch
+/abs/.wt/feature-branch/some/path  # instead of /abs/.wt/feature-branch
+
+# Use --relative flag for a single invocation
+$ git wt --relative feature-branch
+```
+
+Default: `false`
+
+> [!NOTE]
+> If the subdirectory does not exist in the target worktree, the output falls back to the worktree root path.
+
 ## Recipes
 
 ### peco

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ var (
 	copyFlag           []string
 	hookFlag           []string
 	allowDeleteDefault bool
+	relativeFlag       bool
 )
 
 var rootCmd = &cobra.Command{
@@ -133,7 +134,15 @@ Configuration:
       - false (default): Always cd to worktree
     Note: --nocd flag always prevents cd regardless of config value.
     Using --nocd with --init disables git() wrapper (wt.nocd config does not).
-    Example: git config wt.nocd create`,
+    Example: git config wt.nocd create
+
+  wt.relative (--relative)
+    Append the current subdirectory path to the worktree output path.
+    When running from a subdirectory, the output path will include the
+    subdirectory relative to the repository root (like git diff --relative).
+    Falls back to worktree root if the subdirectory does not exist in the worktree.
+    Default: false
+    Example: git config wt.relative true`,
 	RunE:              runRoot,
 	Args:              cobra.ArbitraryArgs,
 	ValidArgsFunction: completeBranches,
@@ -169,6 +178,7 @@ func init() {
 	rootCmd.Flags().StringArrayVar(&copyFlag, "copy", nil, "Always copy files matching pattern (can be specified multiple times)")
 	rootCmd.Flags().StringArrayVar(&hookFlag, "hook", nil, "Run command after creating new worktree (can be specified multiple times)")
 	rootCmd.Flags().BoolVar(&allowDeleteDefault, "allow-delete-default", false, "Allow deletion of the default branch (main, master)")
+	rootCmd.Flags().BoolVar(&relativeFlag, "relative", false, "Append current subdirectory to worktree path (like git diff --relative)")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
@@ -240,6 +250,9 @@ func loadConfig(ctx context.Context, cmd *cobra.Command) (git.Config, error) {
 	}
 	if cmd.Flags().Changed("hook") {
 		cfg.Hooks = hookFlag
+	}
+	if cmd.Flags().Changed("relative") {
+		cfg.Relative = relativeFlag
 	}
 
 	return cfg, nil
@@ -637,7 +650,7 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, branch, startPoint 
 	if wt != nil {
 		// Worktree exists, print path to stdout
 		// start-point is ignored when switching to existing worktree
-		fmt.Println(wt.Path)
+		fmt.Println(resolveRelative(ctx, wt.Path, cfg.Relative))
 		return nil
 	}
 
@@ -669,13 +682,29 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, branch, startPoint 
 	// Run hooks after creating new worktree
 	if err := git.RunHooks(ctx, cfg.Hooks, wtPath, os.Stderr); err != nil {
 		// Print path but return error so shell integration won't cd
-		fmt.Println(wtPath)
+		fmt.Println(resolveRelative(ctx, wtPath, cfg.Relative))
 		return err
 	}
 
 	// Print path to stdout
-	fmt.Println(wtPath)
+	fmt.Println(resolveRelative(ctx, wtPath, cfg.Relative))
 	return nil
+}
+
+func resolveRelative(ctx context.Context, wtPath string, relative bool) string {
+	if !relative {
+		return wtPath
+	}
+	prefix, err := git.ShowPrefix(ctx)
+	if err != nil || prefix == "" {
+		return wtPath
+	}
+	resolved := filepath.Join(wtPath, prefix)
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return wtPath
+	}
+	return resolved
 }
 
 // uniqueArgs removes duplicates from args while preserving order.

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/k1LoW/git-wt/testutil"
 )
 
+func TestShowPrefix(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	repo.CreateFile("README.md", "# Test")
+	repo.CreateFile("some/path/file.txt", "content")
+	repo.Commit("initial commit")
+
+	t.Run("at_repo_root", func(t *testing.T) {
+		restore := repo.Chdir()
+		defer restore()
+
+		prefix, err := ShowPrefix(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if prefix != "" {
+			t.Errorf("ShowPrefix() at root = %q, want empty string", prefix) //nostyle:errorstrings
+		}
+	})
+
+	t.Run("in_subdirectory", func(t *testing.T) {
+		restore := repo.Chdir()
+		defer restore()
+
+		subdir := filepath.Join(repo.Root, "some", "path")
+		if err := os.Chdir(subdir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		prefix, err := ShowPrefix(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if prefix != "some/path" {
+			t.Errorf("ShowPrefix() in subdir = %q, want %q", prefix, "some/path") //nostyle:errorstrings
+		}
+	})
+}
+
 func TestGitConfig(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")


### PR DESCRIPTION
This pull request introduces a new feature that allows the `git wt` command to append the current subdirectory path to the worktree output path, similar to `git diff --relative`. This behavior can be enabled via the `wt.relative` config or the `--relative` flag, and includes robust handling and documentation. Comprehensive tests are also added to ensure correct functionality and fallback behavior.

New feature: relative worktree path resolution

* Added the `wt.relative` config option and `--relative` flag to enable appending the current subdirectory path to the worktree output path; includes fallback to worktree root if the subdirectory does not exist in the target worktree. (`cmd/root.go`, `internal/git/config.go`, `README.md`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR52) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL136-R145) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR181) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR254-R256) [[5]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL640-R653) [[6]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL672-R709) [[7]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR22) [[8]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR35) [[9]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR178-R184) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R222-R242)
* Implemented the `resolveRelative` function to handle path resolution logic, using the new `ShowPrefix` helper to determine the subdirectory relative to the repo root. (`cmd/root.go`, `internal/git/config.go`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL672-R709) [[2]](diffhunk://#diff-879430d2c52499fcaf154539804754af55732e69fffaddbb2545dc53fb612b3bR60-R74)

Shell completion

* Included the `--relative` flag in shell completion options for improved usability. (`e2e/config_test.go`)

closes #106