### PR TITLE
Fix fzf recipe to handle header row and current worktree marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,13 @@ You can use [fzf](https://github.com/junegunn/fzf) for interactive worktree sele
 #### bash/zsh
 
 ``` console
-$ cd $(git-wt | fzf | awk '{print $1}')
+$ cd $(git-wt | fzf --header-lines=1 | awk '{if ($1 == "*") print $2; else print $1}')
 ```
 
 #### fish
 
 ``` console
-$ cd (git-wt | fzf | awk '{print $1}')
+$ cd (git-wt | fzf --header-lines=1 | awk '{if ($1 == "*") print $2; else print $1}')
 ```
 
 ### tmux


### PR DESCRIPTION
## Summary
- Add `--header-lines=1` so the table header is visible but not selectable in fzf
- Fix awk to extract the path correctly when the current worktree (prefixed with `*`) is selected

Fixes #117

## Test plan
- Run `cd $(git-wt | fzf --header-lines=1 | awk '{if ($1 == "*") print $2; else print $1}')` in bash/zsh
- Verify the header row is shown but cannot be selected
- Select the current worktree (marked with `*`) and verify it cds to the correct path
- Select a non-current worktree and verify it cds to the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)