### PR TITLE
feat: add `--json` flag to output worktree list in JSON format

### DIFF
--- a/cmd/json.go
+++ b/cmd/json.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/k1LoW/git-wt/internal/git"
+)
+
+type worktreeJSON struct {
+	Path    string `json:"path"`
+	Branch  string `json:"branch"`
+	Head    string `json:"head"`
+	Bare    bool   `json:"bare"`
+	Current bool   `json:"current"`
+}
+
+func printJSON(w io.Writer, worktrees []git.Worktree, currentPath string) error {
+	items := make([]worktreeJSON, len(worktrees))
+	for i, wt := range worktrees {
+		items[i] = worktreeJSON{
+			Path:    wt.Path,
+			Branch:  wt.Branch,
+			Head:    wt.Head,
+			Bare:    wt.Bare,
+			Current: wt.Path == currentPath,
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(items)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ var (
 	hookFlag           []string
 	allowDeleteDefault bool
 	relativeFlag       bool
+	jsonFlag           bool
 )
 
 var rootCmd = &cobra.Command{
@@ -179,6 +180,7 @@ func init() {
 	rootCmd.Flags().StringArrayVar(&hookFlag, "hook", nil, "Run command after creating new worktree (can be specified multiple times)")
 	rootCmd.Flags().BoolVar(&allowDeleteDefault, "allow-delete-default", false, "Allow deletion of the default branch (main, master)")
 	rootCmd.Flags().BoolVar(&relativeFlag, "relative", false, "Append current subdirectory to worktree path (like git diff --relative)")
+	rootCmd.Flags().BoolVar(&jsonFlag, "json", false, "Output in JSON format")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
@@ -429,6 +431,10 @@ func listWorktrees(ctx context.Context) error {
 	currentPath, err := git.CurrentWorktree(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current worktree: %w", err)
+	}
+
+	if jsonFlag {
+		return printJSON(os.Stdout, worktrees, currentPath)
 	}
 
 	table := tablewriter.NewTable(os.Stdout,


### PR DESCRIPTION
ref: https://github.com/k1LoW/git-wt/issues/123

This pull request introduces a new feature that adds support for JSON output when listing Git worktrees, along with corresponding tests to ensure correct functionality. The main changes involve implementing the JSON output logic, adding a command-line flag to enable it, and verifying the output in the end-to-end test suite.

**New JSON Output Feature:**

* Added a `--json` flag to the CLI, allowing users to output the list of worktrees in JSON format. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR53) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR183)
* Implemented the `printJSON` function in `cmd/json.go` to format and print worktree information as JSON, including fields for path, branch, head, bare status, and whether the worktree is current.
* Modified the `listWorktrees` function to use `printJSON` when the `--json` flag is set.

**Testing:**

* Added an end-to-end test case in `e2e/basic_test.go` to verify that the `--json` flag outputs correctly structured JSON, checks for the presence and correctness of both main and feature worktrees, and validates field values. [[1]](diffhunk://#diff-88a3c7845256943f5d20031d2d43295b15ed5655eb8a05df45eb544a47b5d914R105-R177) [[2]](diffhunk://#diff-88a3c7845256943f5d20031d2d43295b15ed5655eb8a05df45eb544a47b5d914R10)