### PR TITLE
Fix test isolation from user's global git config

### DIFF
--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/k1LoW/exec"
 )
 
+func TestMain(m *testing.M) {
+	// Prevent the user's global/system git config from leaking into tests.
+	// See: https://git-scm.com/docs/git-config#ENVIRONMENT (Git 2.32+)
+	os.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	os.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	os.Exit(m.Run())
+}
+
 // buildBinary builds git-wt binary for testing and returns the path.
 func buildBinary(t *testing.T) string {
 	t.Helper()

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/k1LoW/git-wt/testutil"
 )
 
+func TestMain(m *testing.M) {
+	// Prevent the user's global/system git config from leaking into tests.
+	// See: https://git-scm.com/docs/git-config#ENVIRONMENT (Git 2.32+)
+	os.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	os.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	os.Exit(m.Run())
+}
+
 func TestShowPrefix(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")


### PR DESCRIPTION
## Summary

- Add `TestMain` to `internal/git` and `e2e` test packages to set `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null`, preventing user's global/system git config from leaking into tests
- Fixes test failures when `XDG_CONFIG_HOME` is set and `$XDG_CONFIG_HOME/git/config` contains `wt.*` settings

Closes #128

## Details

Tests previously isolated from global git config by setting `HOME` to a temp directory. However, when `XDG_CONFIG_HOME` is explicitly set, Git reads `$XDG_CONFIG_HOME/git/config` regardless of `HOME`, causing 5 test failures:

- `TestLoadConfig`
- `TestIsBaseDirConfigured/not_configured`
- `TestSetConfig`
- `TestE2E_LegacyBaseDirMigration/no_legacy_dir_uses_new_default`
- `TestE2E_LegacyBaseDirMigration/legacy_dir_exists_errors`

Using `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` environment variables ([Git 2.32+](https://git-scm.com/docs/git-config#ENVIRONMENT)) is a more robust approach that works regardless of `XDG_CONFIG_HOME`.

## Test plan

- [x] `make test` passes
- [x] `make ci` passes
- [x] Verified in environment with `XDG_CONFIG_HOME` set and `wt.*` global config present

🤖 Generated with [Claude Code](https://claude.com/claude-code)