### PR TITLE
fix: run git from mainRoot only if we deleted the current worktree

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -559,6 +559,10 @@ func deleteWorktrees(ctx context.Context, branches []string, force bool) error {
 			// Let git branch -d/-D handle the merge check
 			// If we deleted the current worktree, run git from mainRoot since cwd no longer exists
 			if branchExists {
+				dir := ""
+				if needCdToMain {
+					dir = mainRoot
+				}
 				if isDefault && !allowDeleteDefault {
 					// Default branch is protected - only delete worktree
 					if wtDir == wt.Branch {
@@ -566,7 +570,7 @@ func deleteWorktrees(ctx context.Context, branches []string, force bool) error {
 					} else {
 						fmt.Printf("Deleted worktree %q (branch %q is default, not deleted)\n", wtDir, wt.Branch)
 					}
-				} else if err := git.DeleteBranchInDir(ctx, wt.Branch, force, mainRoot); err != nil {
+				} else if err := git.DeleteBranchInDir(ctx, wt.Branch, force, dir); err != nil {
 					// Treat as non-fatal since worktree removal succeeded
 					if wtDir == wt.Branch {
 						fmt.Printf("Deleted worktree, but failed to delete branch %q (use -D to force)\n", wt.Branch)


### PR DESCRIPTION
# Summary of the change

Run git from mainRoot only if we deleted the current worktree

If no upstream for the branch was set, git checks the target branch is fully merged in HEAD. Because HEAD depends on the current working directory and git-wt >= v0.11.0 always specifies "-C mainRoot" to git command, the branch deletion behavior of git-wt was different from the behavior of git branch -d.

This change allows git-wt to specify "-C mainRoot" only if the current working tree is the one being deleted.
It also ensures consistent behavior with deleting branches that have no worktree.

# Problem to be solved

Try renaming the local branch and worktree by copying them and deleting the originals:

```
yoichi@Mac repo % git --version
git version 2.53.0
yoichi@Mac repo % git wt --version
git version 0.20.0
yoichi@Mac repo % git wt a
Preparing worktree (new branch 'a')
HEAD is now at e5583de init
yoichi@Mac a % git commit --allow-empty -m "a"
[a 91aba8a] a
yoichi@Mac a % git wt b
Preparing worktree (new branch 'b')
HEAD is now at 91aba8a a
yoichi@Mac b % git wt -d a
error: the branch 'a' is not fully merged
hint: If you are sure you want to delete it, run 'git branch -D a'
hint: Disable this message with "git config set advice.forceDeleteBranch false"
Deleted worktree, but failed to delete branch "a" (use -D to force)
```

Since the target branch 'a' is at the same revision as the current branch 'b',
deleting the branch 'a' is expected to succeed.

Furthermore, this behavior is inconsistent with git-wt's behavior of deleting branches that are not associated with any worktree.
We can verify the latter by running the command again:

```
yoichi@Mac b % git wt -d a
Deleted branch a (was 91aba8a).
Deleted branch "a" (no worktree was associated)
```