### PR TITLE
fix: print warning to stderr when file copy fails during worktree creation

### DIFF
--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -19,7 +21,8 @@ type CopyOptions struct {
 }
 
 // CopyFilesToWorktree copies files to the new worktree based on options.
-func CopyFilesToWorktree(ctx context.Context, srcRoot, dstRoot string, opts CopyOptions) error {
+// If w is non-nil, warnings about files that fail to copy are written to it.
+func CopyFilesToWorktree(ctx context.Context, srcRoot, dstRoot string, opts CopyOptions, warn io.Writer) error {
 	var files []string
 
 	if opts.CopyIgnored {
@@ -102,7 +105,9 @@ func CopyFilesToWorktree(ctx context.Context, srcRoot, dstRoot string, opts Copy
 		dst := filepath.Join(dstRoot, file)
 
 		if err := copyFile(src, dst); err != nil {
-			// Skip files that fail to copy (e.g., permission issues)
+			if warn != nil {
+				fmt.Fprintf(warn, "warning: failed to copy %s: %v\n", file, err)
+			}
 			continue
 		}
 	}

--- a/internal/git/copy_test.go
+++ b/internal/git/copy_test.go
@@ -28,7 +28,7 @@ func TestCopyFilesToWorktree_Ignored(t *testing.T) {
 	defer restore()
 
 	opts := CopyOptions{CopyIgnored: true}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestCopyFilesToWorktree_Untracked(t *testing.T) {
 	defer restore()
 
 	opts := CopyOptions{CopyUntracked: true}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestCopyFilesToWorktree_Modified(t *testing.T) {
 	defer restore()
 
 	opts := CopyOptions{CopyModified: true}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCopyFilesToWorktree_NoOptions(t *testing.T) {
 
 	// No copy options enabled
 	opts := CopyOptions{}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestCopyFilesToWorktree_Subdirectory(t *testing.T) {
 	defer restore()
 
 	opts := CopyOptions{CopyIgnored: true}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestCopyFilesToWorktree_NoCopy(t *testing.T) {
 		CopyIgnored: true,
 		NoCopy:      []string{"*.log", "vendor/"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCopyFilesToWorktree_NoCopy_GitignorePatterns(t *testing.T) {
 		CopyIgnored: true,
 		NoCopy:      []string{"build/"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestCopyFilesToWorktree_Copy(t *testing.T) {
 		CopyIgnored: false,
 		Copy:        []string{"*.code-workspace"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestCopyFilesToWorktree_Copy_WithNoCopy(t *testing.T) {
 		Copy:        []string{"*.code-workspace"},
 		NoCopy:      []string{"other.code-workspace"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -422,7 +422,7 @@ func TestCopyFilesToWorktree_Copy_MultiplePatterns(t *testing.T) {
 		CopyIgnored: false,
 		Copy:        []string{"*.code-workspace", ".vscode/"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestCopyFilesToWorktree_Copy_WithCopyIgnored(t *testing.T) {
 		CopyIgnored: true,
 		Copy:        []string{"*.code-workspace"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestCopyFilesToWorktree_Copy_MatchesUntrackedFiles(t *testing.T) {
 		CopyIgnored: false,
 		Copy:        []string{"untracked.txt"},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}
@@ -582,7 +582,7 @@ func TestCopyFilesToWorktree_ExcludeDirs(t *testing.T) {
 		CopyIgnored: true,
 		ExcludeDirs: []string{filepath.Join(repo.Root, ".worktrees")},
 	}
-	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts)
+	err := CopyFilesToWorktree(t.Context(), repo.Root, dstDir, opts, nil)
 	if err != nil {
 		t.Fatalf("CopyFilesToWorktree failed: %v", err)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -235,7 +235,7 @@ func AddWorktree(ctx context.Context, path, branch string, copyOpts CopyOptions)
 	copyOpts.ExcludeDirs = append(copyOpts.ExcludeDirs, parentDir)
 
 	// Copy files to new worktree
-	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts); err != nil {
+	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts, os.Stderr); err != nil {
 		return fmt.Errorf("failed to copy files: %w", err)
 	}
 
@@ -282,7 +282,7 @@ func AddWorktreeWithNewBranch(ctx context.Context, path, branch, startPoint stri
 	copyOpts.ExcludeDirs = append(copyOpts.ExcludeDirs, parentDir)
 
 	// Copy files to new worktree
-	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts); err != nil {
+	if err := CopyFilesToWorktree(ctx, srcRoot, path, copyOpts, os.Stderr); err != nil {
 		return fmt.Errorf("failed to copy files: %w", err)
 	}
 


### PR DESCRIPTION
This pull request enhances the file copying process when creating new Git worktrees by adding support for reporting warnings about files that fail to copy. The main change is the addition of a `warn` parameter to the `CopyFilesToWorktree` function, allowing warnings to be written to a specified writer (such as `os.Stderr`). The tests and worktree creation logic are updated to accommodate this new parameter.

Enhancements to file copying and error reporting:

* Added an optional `warn io.Writer` parameter to the `CopyFilesToWorktree` function in `internal/git/copy.go`, enabling warnings about failed file copies to be written to the provided writer.
* Updated the file copying loop in `CopyFilesToWorktree` to print a warning message when a file fails to copy, if `warn` is non-nil.

Integration with worktree creation:

* Modified `AddWorktree` and `AddWorktreeWithNewBranch` in `internal/git/worktree.go` to pass `os.Stderr` as the warning writer, so warnings are shown to users during worktree creation. [[1]](diffhunk://#diff-1d15956ec34695c60e782d8cfa4a26d35b179761173056d985c7587d854d5e23L238-R238) [[2]](diffhunk://#diff-1d15956ec34695c60e782d8cfa4a26d35b179761173056d985c7587d854d5e23L285-R285)