### PR TITLE
fix: improve error handling in file copy, init output, and worktree lookup

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -357,42 +357,35 @@ Register-ArgumentCompleter -Native -CommandName git -ScriptBlock $scriptBlock
 `
 
 func runInit(shell string, ignoreSwitchDirectory bool) error {
+	var header, wrapper, completion string
 	switch shell {
 	case "bash":
-		fmt.Fprint(os.Stdout, "# git-wt shell hook for bash\n")
-		if !ignoreSwitchDirectory {
-			fmt.Fprint(os.Stdout, bashGitWrapper)
-		}
-		fmt.Fprint(os.Stdout, bashCompletion)
-		return nil
+		header = "# git-wt shell hook for bash\n"
+		wrapper = bashGitWrapper
+		completion = bashCompletion
 	case "zsh":
-		fmt.Fprint(os.Stdout, "# git-wt shell hook for zsh\n")
-		if !ignoreSwitchDirectory {
-			fmt.Fprint(os.Stdout, zshGitWrapper)
-		}
-		fmt.Fprint(os.Stdout, zshCompletion)
-		return nil
+		header = "# git-wt shell hook for zsh\n"
+		wrapper = zshGitWrapper
+		completion = zshCompletion
 	case "fish":
-		if _, err := io.WriteString(os.Stdout, "# git-wt shell hook for fish\n"); err != nil {
-			return err
-		}
-		if !ignoreSwitchDirectory {
-			if _, err := io.WriteString(os.Stdout, fishGitWrapper); err != nil {
-				return err
-			}
-		}
-		if _, err := io.WriteString(os.Stdout, fishCompletion); err != nil {
-			return err
-		}
-		return nil
+		header = "# git-wt shell hook for fish\n"
+		wrapper = fishGitWrapper
+		completion = fishCompletion
 	case "powershell":
-		fmt.Fprint(os.Stdout, "# git-wt shell hook for PowerShell\n")
-		if !ignoreSwitchDirectory {
-			fmt.Fprint(os.Stdout, powershellGitWrapper)
-		}
-		fmt.Fprint(os.Stdout, powershellCompletion)
-		return nil
+		header = "# git-wt shell hook for PowerShell\n"
+		wrapper = powershellGitWrapper
+		completion = powershellCompletion
 	default:
 		return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish, powershell)", shell)
 	}
+	if _, err := io.WriteString(os.Stdout, header); err != nil {
+		return err
+	}
+	if !ignoreSwitchDirectory {
+		if _, err := io.WriteString(os.Stdout, wrapper); err != nil {
+			return err
+		}
+	}
+	_, err := io.WriteString(os.Stdout, completion)
+	return err
 }

--- a/internal/git/copy_file.go
+++ b/internal/git/copy_file.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 )
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -39,7 +39,11 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/git/copy_file_darwin.go
+++ b/internal/git/copy_file_darwin.go
@@ -42,7 +42,7 @@ func copyFile(src, dst string) error {
 	return copyFileTraditional(src, dst, srcInfo)
 }
 
-func copyFileTraditional(src, dst string, srcInfo os.FileInfo) error {
+func copyFileTraditional(src, dst string, srcInfo os.FileInfo) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -53,7 +53,11 @@ func copyFileTraditional(src, dst string, srcInfo os.FileInfo) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -167,12 +167,12 @@ func FindWorktreeByBranchOrDir(ctx context.Context, query string) (*Worktree, er
 	if info, err := os.Stat(query); err == nil && info.IsDir() {
 		absPath, err := filepath.Abs(query)
 		if err != nil {
-			return nil, nil
+			return nil, fmt.Errorf("failed to get absolute path for %q: %w", query, err)
 		}
 		// Resolve symlinks (e.g., macOS /var -> /private/var)
 		absPath, err = filepath.EvalSymlinks(absPath)
 		if err != nil {
-			return nil, nil
+			return nil, fmt.Errorf("failed to resolve symlinks for %q: %w", absPath, err)
 		}
 		for _, wt := range worktrees {
 			wtPath, err := filepath.EvalSymlinks(wt.Path)


### PR DESCRIPTION
This pull request includes several improvements focused on error handling, code clarity, and shell support. The main changes are enhanced error reporting in file operations and worktree lookups, improved resource management when copying files, and a refactor of the shell initialization logic for better maintainability and PowerShell support.

**Error handling and reporting improvements:**

* [`internal/git/worktree.go`](diffhunk://#diff-1d15956ec34695c60e782d8cfa4a26d35b179761173056d985c7587d854d5e23L170-R175): Improved error reporting in `FindWorktreeByBranchOrDir` by returning detailed errors when failing to get the absolute path or resolve symlinks, instead of silently returning `nil`.

* `internal/git/copy_file.go`, `internal/git/copy_file_darwin.go`: Changed the signatures of `copyFile` and `copyFileTraditional` to named return values and updated the `defer out.Close()` logic to properly propagate file close errors, ensuring resource management issues are correctly reported. [[1]](diffhunk://#diff-e3050079d85dd2cb00ba0225ea95d38b452dc65076f5bfa8b581f4baa91c8a5eL16-R16) [[2]](diffhunk://#diff-e3050079d85dd2cb00ba0225ea95d38b452dc65076f5bfa8b581f4baa91c8a5eL42-R46) [[3]](diffhunk://#diff-345bf369212dc73a438ebcaa796808851a6451fb3a223fe5ccf034fee4910d1bL45-R45) [[4]](diffhunk://#diff-345bf369212dc73a438ebcaa796808851a6451fb3a223fe5ccf034fee4910d1bL56-R60)

**Shell initialization logic and support:**

* [`cmd/init.go`](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR360-L398): Refactored the `runInit` function to use common variables for shell script output, reducing code duplication. Added improved error handling for unsupported shells and unified logic for all supported shells, including explicit support for PowerShell.