### PR TITLE
feat: support add/switch operations in bare repositories

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,8 @@ Note: The default branch (e.g., main, master) is protected from accidental delet
       - Without worktree: deletion is blocked entirely.
       Use --allow-delete-default to override and delete the branch.
 
-Note: Bare repositories are not currently supported.
+Note: Bare repositories are supported for list and add/switch operations.
+      Delete operation in bare repositories is not yet supported.
       See https://github.com/k1LoW/git-wt/issues/130 for details.
 
 Shell Integration:
@@ -251,12 +252,6 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	// git wt <branch> [<start-point>]
 	if len(args) > 2 {
 		return fmt.Errorf("too many arguments: expected <branch> [<start-point>], got %d arguments", len(args))
-	}
-
-	// Guard: bare repositories are not supported for add/switch operation.
-	// Remove this guard when bare add/switch support is implemented.
-	if err := git.AssertNotBareRepository(ctx); err != nil {
-		return err
 	}
 
 	branch := args[0]

--- a/e2e/bare_test.go
+++ b/e2e/bare_test.go
@@ -2,7 +2,8 @@
 //
 // Covered scenarios:
 //   - List operation: supported in both bare root and worktrees from bare repos
-//   - Add/switch, delete operations: not yet supported, should return errors
+//   - Add/switch operations: supported in both bare root and worktrees from bare repos
+//   - Delete operation: not yet supported, should return errors
 package e2e
 
 import (
@@ -189,38 +190,111 @@ func TestE2E_BareRepository(t *testing.T) {
 		}
 	})
 
-	// --- Tests for operations that still don't support bare repositories ---
+	// --- Tests for add/switch operations in bare repositories ---
 
 	t.Run("direct_bare_add", func(t *testing.T) {
 		t.Parallel()
 		bareRepo := testutil.NewBareTestRepo(t)
 
-		// Run git-wt with a branch name (add/switch mode) inside the bare repo
-		out, err := runGitWt(t, binPath, bareRepo.Root, "feature")
-		if err == nil {
-			t.Fatalf("expected error for bare repository, but succeeded with output: %s", out)
+		// Run git-wt with a branch name (add mode) inside the bare repo
+		// Should create a new worktree with a new branch
+		stdout, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "feature")
+		if err != nil {
+			t.Fatalf("expected success for bare repository add, but got error: %v\nstdout: %s", err, stdout)
 		}
-		if !strings.Contains(out, "bare") {
-			t.Errorf("error message should mention 'bare', got: %s", out)
+		wtPath := worktreePath(stdout)
+		if wtPath == "" {
+			t.Fatal("expected worktree path in stdout, got empty")
+		}
+		// Verify the worktree directory exists
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory should exist at %s", wtPath)
 		}
 	})
 
-	t.Run("direct_bare_delete", func(t *testing.T) {
+	t.Run("direct_bare_add_existing_branch", func(t *testing.T) {
 		t.Parallel()
 		bareRepo := testutil.NewBareTestRepo(t)
 
-		// Run git-wt with -d flag (delete mode) inside the bare repo
-		out, err := runGitWt(t, binPath, bareRepo.Root, "-d", "main")
-		if err == nil {
-			t.Fatalf("expected error for bare repository, but succeeded with output: %s", out)
+		// Create a branch in the bare repo
+		cmd := exec.Command("git", "-C", bareRepo.Root, "branch", "existing-branch", "main")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch failed: %v\noutput: %s", err, out)
 		}
-		if !strings.Contains(out, "bare") {
-			t.Errorf("error message should mention 'bare', got: %s", out)
+
+		// Run git-wt with the existing branch name
+		stdout, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "existing-branch")
+		if err != nil {
+			t.Fatalf("expected success for bare repository add with existing branch, but got error: %v\nstdout: %s", err, stdout)
+		}
+		wtPath := worktreePath(stdout)
+		if wtPath == "" {
+			t.Fatal("expected worktree path in stdout, got empty")
+		}
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory should exist at %s", wtPath)
+		}
+	})
+
+	t.Run("direct_bare_add_with_start_point", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewBareTestRepo(t)
+
+		// Run git-wt with branch name and start-point
+		stdout, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "feature-from-main", "main")
+		if err != nil {
+			t.Fatalf("expected success for bare repository add with start-point, but got error: %v\nstdout: %s", err, stdout)
+		}
+		wtPath := worktreePath(stdout)
+		if wtPath == "" {
+			t.Fatal("expected worktree path in stdout, got empty")
+		}
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory should exist at %s", wtPath)
+		}
+	})
+
+	t.Run("direct_bare_switch_existing", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewBareTestRepo(t)
+
+		// First, create a worktree
+		stdout1, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "switch-test")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v\nstdout: %s", err, stdout1)
+		}
+		createdPath := worktreePath(stdout1)
+
+		// Run git-wt again with the same branch - should switch (return same path)
+		stdout2, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "switch-test")
+		if err != nil {
+			t.Fatalf("expected success for switch to existing worktree, but got error: %v\nstdout: %s", err, stdout2)
+		}
+		switchPath := worktreePath(stdout2)
+		if switchPath != createdPath {
+			t.Errorf("switch should return same path as creation\ncreated: %s\nswitch:  %s", createdPath, switchPath)
+		}
+	})
+
+	t.Run("dotgit_bare_add", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewDotGitBareTestRepo(t)
+
+		// Run git-wt with a branch name inside the dotgit bare repo
+		stdout, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "feature")
+		if err != nil {
+			t.Fatalf("expected success for dotgit bare repository add, but got error: %v\nstdout: %s", err, stdout)
+		}
+		wtPath := worktreePath(stdout)
+		if wtPath == "" {
+			t.Fatal("expected worktree path in stdout, got empty")
+		}
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory should exist at %s", wtPath)
 		}
 	})
 
 	// --- Tests running inside a worktree created from a bare repository ---
-	// (operations that still don't support bare repos)
 
 	t.Run("worktree_from_bare_add", func(t *testing.T) {
 		t.Parallel()
@@ -234,10 +308,100 @@ func TestE2E_BareRepository(t *testing.T) {
 		}
 		t.Cleanup(func() { os.RemoveAll(wtPath) })
 
-		// Run git-wt with a branch name (add/switch mode) inside the worktree
-		out, err := runGitWt(t, binPath, wtPath, "feature")
+		// Run git-wt with a branch name (add mode) inside the worktree
+		// Should succeed: bare-derived worktrees support add
+		stdout, _, err := runGitWtStdout(t, binPath, wtPath, "feature2")
+		if err != nil {
+			t.Fatalf("expected success for worktree from bare repo add, but got error: %v\nstdout: %s", err, stdout)
+		}
+		newWtPath := worktreePath(stdout)
+		if newWtPath == "" {
+			t.Fatal("expected worktree path in stdout, got empty")
+		}
+		if _, err := os.Stat(newWtPath); os.IsNotExist(err) {
+			t.Fatalf("new worktree directory should exist at %s", newWtPath)
+		}
+	})
+
+	t.Run("worktree_from_bare_add_copies_files", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewBareTestRepo(t)
+
+		// Create a worktree from the bare repo
+		wtPath := filepath.Join(bareRepo.ParentDir(), "wt-main")
+		cmd := exec.Command("git", "-C", bareRepo.Root, "worktree", "add", wtPath, "main")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git worktree add failed: %v\noutput: %s", err, out)
+		}
+		t.Cleanup(func() { os.RemoveAll(wtPath) })
+
+		// Create an untracked file in the source worktree to test copy behavior
+		if err := os.WriteFile(filepath.Join(wtPath, "untracked.txt"), []byte("test content\n"), 0600); err != nil {
+			t.Fatalf("failed to create untracked.txt: %v", err)
+		}
+
+		// Run git-wt with --copyuntracked to copy untracked files
+		stdout, _, err := runGitWtStdout(t, binPath, wtPath, "--copyuntracked", "feature-copy")
+		if err != nil {
+			t.Fatalf("expected success, but got error: %v\nstdout: %s", err, stdout)
+		}
+		newWtPath := worktreePath(stdout)
+
+		// Verify the untracked file was copied to the new worktree
+		copiedPath := filepath.Join(newWtPath, "untracked.txt")
+		if _, err := os.Stat(copiedPath); os.IsNotExist(err) {
+			t.Errorf("untracked.txt should be copied to new worktree at %s", copiedPath)
+		}
+	})
+
+	t.Run("bare_add_chain", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewBareTestRepo(t)
+
+		// Step 1: Create worktree A from bare root
+		stdoutA, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "feature-a")
+		if err != nil {
+			t.Fatalf("failed to create worktree A from bare root: %v\nstdout: %s", err, stdoutA)
+		}
+		wtPathA := worktreePath(stdoutA)
+		if wtPathA == "" {
+			t.Fatal("expected worktree A path in stdout, got empty")
+		}
+
+		// Step 2: Create worktree B from worktree A (bare-derived)
+		stdoutB, _, err := runGitWtStdout(t, binPath, wtPathA, "feature-b")
+		if err != nil {
+			t.Fatalf("failed to create worktree B from worktree A: %v\nstdout: %s", err, stdoutB)
+		}
+		wtPathB := worktreePath(stdoutB)
+		if wtPathB == "" {
+			t.Fatal("expected worktree B path in stdout, got empty")
+		}
+		if _, err := os.Stat(wtPathB); os.IsNotExist(err) {
+			t.Fatalf("worktree B directory should exist at %s", wtPathB)
+		}
+
+		// Step 3: Switch back to A from bare root (should return existing path)
+		stdoutSwitch, _, err := runGitWtStdout(t, binPath, bareRepo.Root, "feature-a")
+		if err != nil {
+			t.Fatalf("failed to switch to worktree A: %v\nstdout: %s", err, stdoutSwitch)
+		}
+		switchPath := worktreePath(stdoutSwitch)
+		if switchPath != wtPathA {
+			t.Errorf("switch should return same path as creation\ncreated: %s\nswitch:  %s", wtPathA, switchPath)
+		}
+	})
+
+	// --- Tests for operations that still don't support bare repositories ---
+
+	t.Run("direct_bare_delete", func(t *testing.T) {
+		t.Parallel()
+		bareRepo := testutil.NewBareTestRepo(t)
+
+		// Run git-wt with -d flag (delete mode) inside the bare repo
+		out, err := runGitWt(t, binPath, bareRepo.Root, "-d", "main")
 		if err == nil {
-			t.Fatalf("expected error for worktree from bare repo, but succeeded with output: %s", out)
+			t.Fatalf("expected error for bare repository, but succeeded with output: %s", out)
 		}
 		if !strings.Contains(out, "bare") {
 			t.Errorf("error message should mention 'bare', got: %s", out)

--- a/internal/git/repo_context.go
+++ b/internal/git/repo_context.go
@@ -207,19 +207,6 @@ func ShowPrefix(ctx context.Context) (string, error) {
 	return strings.TrimSuffix(strings.TrimSpace(string(out)), "/"), nil
 }
 
-// RepoRoot returns the root directory of the current git repository (or worktree).
-func RepoRoot(ctx context.Context) (string, error) {
-	cmd, err := gitCommand(ctx, "rev-parse", "--show-toplevel")
-	if err != nil {
-		return "", err
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
 // MainRepoRoot returns the root directory of the main git repository.
 // Unlike RepoRoot, this returns the main repository root even when called from a worktree.
 //

--- a/internal/git/repo_context_test.go
+++ b/internal/git/repo_context_test.go
@@ -368,43 +368,6 @@ func TestShowPrefix(t *testing.T) {
 	})
 }
 
-func TestRepoRoot(t *testing.T) {
-	repo := testutil.NewTestRepo(t)
-	repo.CreateFile("README.md", "# Test")
-	repo.Commit("initial commit")
-
-	// Create a subdirectory
-	repo.CreateFile("subdir/file.txt", "content")
-	repo.Commit("add subdir")
-
-	restore := repo.Chdir()
-	defer restore()
-
-	root, err := RepoRoot(t.Context())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if root != repo.Root {
-		t.Errorf("RepoRoot() = %q, want %q", root, repo.Root) //nostyle:errorstrings
-	}
-
-	// Test from subdirectory
-	subdir := filepath.Join(repo.Root, "subdir")
-	if err := os.Chdir(subdir); err != nil {
-		t.Fatalf("failed to chdir to subdir: %v", err)
-	}
-
-	root, err = RepoRoot(t.Context())
-	if err != nil {
-		t.Fatalf("unexpected error from subdir: %v", err)
-	}
-
-	if root != repo.Root {
-		t.Errorf("RepoRoot() from subdir = %q, want %q", root, repo.Root) //nostyle:errorstrings
-	}
-}
-
 func TestMainRepoRoot(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")


### PR DESCRIPTION
## Summary

#130 (Phase 2: add/switch operations)

- Enable `git wt <branch>` (add/switch mode) in bare repositories and worktrees created from bare repos
- Remove `AssertNotBareRepository()` guard for add/switch operations
- Remove duplicate `RepoRoot()` (identical to `CurrentWorktree()`)
- Extract `prepareAdd()` / `copyAfterAdd()` helpers to share bare-aware logic between `AddWorktree` and `AddWorktreeWithNewBranch`
- Skip file copying when running from bare root (no working tree to copy from)
- Skip bare entries in `FindWorktreeByBranchOrDir()` to prevent matching the bare root as a worktree target
- Fix ExcludeDirs logic: when source worktree is inside the basedir (bare-derived worktree), do not exclude the basedir from copy

## Behavior

### From bare root

```
$ cd /tmp/repo.git
$ git wt feature
# Creates new worktree with new branch "feature"
# No file copying (bare root has no working tree)

$ git wt feature
# Switches to existing worktree (outputs path)
```

### From bare-derived worktree

```
$ cd /tmp/.wt/main
$ git wt feature2
# Creates new worktree with new branch "feature2"
# Copies untracked/ignored/modified files from current worktree (same as normal repos)
```

## Operations NOT yet supported in bare repos

- `git wt -d <branch>` (delete) — still returns error mentioning "bare"

## Notes

- I noticed that staged new files (added with git add but not yet committed) are not being copied. However, since this is out of scope for this PR, I’m leaving it as-is for now.

## Test plan

- [x] Unit tests for `AddWorktree` / `AddWorktreeWithNewBranch` from bare repository
- [x] Unit tests for `FindWorktreeByBranchOrDir` bare entry skipping
- [x] E2E tests for direct bare add (new branch)
- [x] E2E tests for direct bare add with existing branch
- [x] E2E tests for direct bare add with start-point
- [x] E2E tests for bare switch to existing worktree
- [x] E2E tests for dotgit bare add (`core.bare=true` layout)
- [x] E2E tests for worktree-from-bare add
- [x] E2E tests for worktree-from-bare add with file copying (`--copyuntracked`)
- [x] E2E tests for bare add chain (bare → wt A → wt B → switch back)
- [x] E2E tests confirming delete still returns errors for bare repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)