### PR TITLE
fix: use custom version template to output "git-wt version" instead of "git version"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,6 +178,8 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.SetVersionTemplate(fmt.Sprintf("%s version {{.Version}}\n", version.Name))
+
 	// Disable Cobra's default "completion" subcommand.
 	// git-wt uses its own shell integration via --init flag instead.
 	rootCmd.CompletionOptions.DisableDefaultCmd = true

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -652,8 +652,8 @@ func TestE2E_CLI(t *testing.T) {
 			t.Fatalf("git-wt --version failed: %v\noutput: %s", err, out)
 		}
 
-		if !strings.Contains(out, "version") {
-			t.Errorf("expected version output, got: %s", out)
+		if !strings.Contains(out, "git-wt version") {
+			t.Errorf("expected 'git-wt version' in output, got: %s", out)
 		}
 	})
 


### PR DESCRIPTION
closes https://github.com/k1LoW/git-wt/issues/138

This pull request makes a minor improvement to the version output of the CLI and updates the related end-to-end test to match the new output format.

- CLI Output Enhancement:
  * Updated the version output template in `rootCmd` to include the program name (e.g., `git-wt version x.y.z`) for clearer identification.

- Test Update:
  * Adjusted the end-to-end test in `e2e/basic_test.go` to expect the new version output format (`git-wt version`).