### PR TITLE
feat: support delete operation in bare repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ The target can be specified as:
 When deleting, the same target types apply: `git wt -d feature-branch`, `git wt -d .`, `git wt -d ../sibling`
 
 > [!NOTE]
-> Bare repositories are not currently supported.
-> Bare repository support is planned: see [#130](https://github.com/k1LoW/git-wt/issues/130) for details.
-
-> [!NOTE]
 > The default branch (e.g., main, master) is protected from accidental deletion.
 > - If the default branch has a worktree, the worktree is deleted but the branch is preserved.
 > - If the default branch has no worktree, deletion is blocked entirely.

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -185,6 +186,24 @@ func DefaultBranch(ctx context.Context) (string, error) {
 		configBranch = gitDefaultBranch
 	}
 	return configBranch, nil
+}
+
+// HeadBranch returns the branch name that HEAD points to.
+// Returns an error if HEAD is detached or not a symbolic ref.
+func HeadBranch(ctx context.Context) (string, error) {
+	cmd, err := gitCommand(ctx, "symbolic-ref", "HEAD", "--short")
+	if err != nil {
+		return "", fmt.Errorf("failed to create git command: %w", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD (HEAD may be detached): %w", err)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		return "", fmt.Errorf("symbolic-ref HEAD resolved to empty string")
+	}
+	return branch, nil
 }
 
 // IsDefaultBranch checks if the given branch name is the default branch.

--- a/internal/git/repo_context.go
+++ b/internal/git/repo_context.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,17 +42,6 @@ func RepoContextFrom(ctx context.Context) *RepoContext {
 	}
 	return rc
 }
-
-// ErrBareRepository is a sentinel error returned when a bare repository is
-// detected but the requested operation does not support bare repositories.
-//
-// Bare repositories lack a working tree, so many git-wt operations
-// (list, add/switch, delete) cannot function correctly in them.
-// Support for bare repositories is tracked in the linked issue.
-var ErrBareRepository = errors.New(
-	"bare repositories are not currently supported by git-wt\n" +
-		"For more information, see: https://github.com/k1LoW/git-wt/issues/130",
-)
 
 // DetectRepoContext detects whether the current repository is bare and whether
 // the current working directory is inside a linked worktree.
@@ -114,23 +102,6 @@ func IsBareRepository(ctx context.Context) (bool, error) {
 	return rc.bare, nil
 }
 
-// AssertNotBareRepository returns ErrBareRepository if the current repository
-// is bare. This is used as a guard at the beginning of operations that do not
-// support bare repositories.
-//
-// When bare repository support is added for a specific operation, its guard
-// call can simply be removed. This design allows staged (per-operation)
-// enablement of bare repository support.
-func AssertNotBareRepository(ctx context.Context) error {
-	isBare, err := IsBareRepository(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to check repository type: %w", err)
-	}
-	if isBare {
-		return ErrBareRepository
-	}
-	return nil
-}
 
 // IsNormalMain reports whether the current directory is the main working tree
 // of a normal (non-bare) repository.

--- a/internal/git/repo_context_test.go
+++ b/internal/git/repo_context_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -243,44 +242,6 @@ func TestIsBareRepository_WorktreeFromBare(t *testing.T) {
 	}
 }
 
-func TestAssertNotBareRepository_NormalRepo(t *testing.T) {
-	repo := testutil.NewTestRepo(t)
-	repo.CreateFile("README.md", "# Test")
-	repo.Commit("initial commit")
-
-	restore := repo.Chdir()
-	defer restore()
-
-	err := AssertNotBareRepository(t.Context())
-	if err != nil {
-		t.Errorf("expected nil from AssertNotBareRepository for normal repo, got: %v", err)
-	}
-}
-
-func TestAssertNotBareRepository_BareRepo(t *testing.T) {
-	bareRepo := testutil.NewBareTestRepo(t)
-
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get cwd: %v", err)
-	}
-	if err := os.Chdir(bareRepo.Root); err != nil {
-		t.Fatalf("failed to chdir: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(origDir); err != nil {
-			t.Fatalf("failed to restore cwd: %v", err)
-		}
-	}()
-
-	err = AssertNotBareRepository(t.Context())
-	if err == nil {
-		t.Fatal("AssertNotBareRepository should return error for bare repo")
-	}
-	if !errors.Is(err, ErrBareRepository) {
-		t.Errorf("expected ErrBareRepository, got: %v", err)
-	}
-}
 
 func TestWithRepoContext_CacheHit(t *testing.T) {
 	repo := testutil.NewTestRepo(t)


### PR DESCRIPTION
## Summary

#130 (Phase 3: delete operation)

This is the final phase of #130. With this PR, all bare repository operations are now supported:

- [x] Phase 1: list command (#140)
- [x] Phase 2: add/switch commands (#147)
- [x] Phase 3: delete command (this PR)
- [ ] Phase X: some refactoring with repo_context and e2e/bare_test (Extra)

## Changes

- Enable `git wt -d <branch>` and `git wt -D <branch>` in bare repositories and worktrees created from bare repos
- Remove `AssertNotBareRepository()` guard for delete operations
- Add `IsBareEntry()` to detect and protect the bare repository root entry from deletion
- Add `HeadBranch()` to resolve the branch HEAD points to (used for bare entry detection by branch name)
- Protect bare entry from deletion via both branch name (`git wt -d main`) and path (`git wt -d .`)
- Remove "bare repositories not supported" notes from README and CLI help (all operations now supported)
- Extract shared test helpers (`createBareWorktree`, `commitUnmergedChange`, `assertLastLine`) for bare delete tests

## Behavior

### Delete from bare root

```
$ cd /tmp/repo.git
$ git wt feature          # create worktree
$ git wt -d feature       # safe delete: works
$ git wt -d main          # delete bare entry: error
cannot delete bare repository entry "main": the bare repository root cannot be removed as a worktree
```

### Delete from bare-derived worktree

```
$ cd /tmp/.wt/feature
$ git wt -d other-branch  # delete another worktree: works
$ git wt -D feature       # delete current worktree: works (cd back to bare root via shell integration)
```

### Delete bare entry via path

```
$ cd /tmp/repo.git
$ git wt -d .             # error: bare entry protected
cannot delete bare repository entry ".": the bare repository root cannot be removed as a worktree
```

## Test plan

- [x] E2E: safe delete of linked worktree from bare root
- [x] E2E: force delete of worktree with unmerged commits from bare root
- [x] E2E: deleting bare entry by branch name returns error
- [x] E2E: deleting bare entry by path (`.`) returns error
- [x] E2E: delete other worktree from bare-derived worktree
- [x] E2E: delete current worktree from inside (shell integration cd to bare root)
- [x] E2E: delete last worktree, cd back to bare root
- [x] E2E: safe delete fails with modified files, suggests `-D`
- [x] E2E: dotgit bare variant (`core.bare=true`) delete works

🤖 Generated with [Claude Code](https://claude.com/claude-code)