### PR TITLE
fix: error when start-point is specified for existing branch or worktree

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -761,7 +761,7 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, wtName, branchName,
 
 	if wt != nil {
 		if startPoint != "" {
-			return fmt.Errorf("worktree %q already exists at %s (start-point %q is not allowed when switching to an existing worktree)", wtName, wt.Path, startPoint)
+			return fmt.Errorf("worktree for branch %q already exists at %s (start-point %q is not allowed when switching to an existing worktree)", wt.Branch, wt.Path, startPoint)
 		}
 		// Worktree exists, switch to it
 		fmt.Println(resolveRelative(ctx, wt.Path, cfg.Relative))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -760,8 +760,10 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, wtName, branchName,
 	}
 
 	if wt != nil {
-		// Worktree exists, print path to stdout
-		// start-point is ignored when switching to existing worktree
+		if startPoint != "" {
+			return fmt.Errorf("worktree %q already exists at %s (start-point %q is not allowed when switching to an existing worktree)", wtName, wt.Path, startPoint)
+		}
+		// Worktree exists, switch to it
 		fmt.Println(resolveRelative(ctx, wt.Path, cfg.Relative))
 		return nil
 	}
@@ -779,8 +781,10 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, wtName, branchName,
 	}
 
 	if exists {
+		if startPoint != "" {
+			return fmt.Errorf("branch %q already exists (start-point %q is not allowed for existing branches)", branchName, startPoint)
+		}
 		// Branch exists, create worktree with existing branch
-		// start-point is ignored when using existing branch
 		if err := git.AddWorktree(ctx, wtPath, branchName, copyOpts); err != nil {
 			return fmt.Errorf("failed to create worktree: %w", err)
 		}

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -441,7 +441,9 @@ func TestE2E_CreateWorktree(t *testing.T) {
 		repo.Commit("initial commit")
 
 		// Create worktree first
-		runGitWt(t, binPath, repo.Root, "feature-branch")
+		if _, err := runGitWt(t, binPath, repo.Root, "feature-branch"); err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
 
 		// Switching to existing worktree with start-point should error
 		_, _, err := runGitWtStdout(t, binPath, repo.Root, "feature-branch", "main")
@@ -472,7 +474,9 @@ func TestE2E_CreateWorktree(t *testing.T) {
 		repo.Commit("initial commit")
 
 		// Create worktree first
-		runGitWt(t, binPath, repo.Root, "feature-branch")
+		if _, err := runGitWt(t, binPath, repo.Root, "feature-branch"); err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
 
 		// Switching to existing worktree with -b and start-point should error
 		_, _, err := runGitWtStdout(t, binPath, repo.Root, "feature-branch", "-b", "feature-branch", "main")

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -420,7 +420,7 @@ func TestE2E_CreateWorktree(t *testing.T) {
 		}
 	})
 
-	t.Run("start_point_ignored_for_existing_branch", func(t *testing.T) {
+	t.Run("start_point_error_for_existing_branch", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)
 		repo.CreateFile("README.md", "# Test")
@@ -428,23 +428,56 @@ func TestE2E_CreateWorktree(t *testing.T) {
 
 		repo.Git("branch", "existing-branch")
 
-		repo.CreateFile("new-file.txt", "new content")
-		repo.Commit("second commit")
-
-		stdout, stderr, err := runGitWtStdout(t, binPath, repo.Root, "existing-branch", "main")
-		if err != nil {
-			t.Fatalf("git-wt failed: %v\nstderr: %s", err, stderr)
+		_, _, err := runGitWtStdout(t, binPath, repo.Root, "existing-branch", "main")
+		if err == nil {
+			t.Fatal("expected error when start-point is specified for existing branch, but got none")
 		}
+	})
 
-		wtPath := strings.TrimSpace(stdout)
-		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
-			t.Fatalf("worktree was not created at %s", wtPath)
+	t.Run("start_point_error_for_existing_worktree", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Create worktree first
+		runGitWt(t, binPath, repo.Root, "feature-branch")
+
+		// Switching to existing worktree with start-point should error
+		_, _, err := runGitWtStdout(t, binPath, repo.Root, "feature-branch", "main")
+		if err == nil {
+			t.Fatal("expected error when start-point is specified for existing worktree, but got none")
 		}
+	})
 
-		// Verify the worktree is based on existing-branch (should NOT have new-file.txt)
-		newFilePath := filepath.Join(wtPath, "new-file.txt")
-		if _, err := os.Stat(newFilePath); !os.IsNotExist(err) {
-			t.Error("worktree should NOT have new-file.txt (start-point should be ignored for existing branch)")
+	t.Run("start_point_error_for_existing_branch_with_b_flag", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		repo.Git("branch", "existing-branch")
+
+		// Creating worktree with -b for existing branch and start-point should error
+		_, _, err := runGitWtStdout(t, binPath, repo.Root, "mydir", "-b", "existing-branch", "main")
+		if err == nil {
+			t.Fatal("expected error when start-point is specified with -b for existing branch, but got none")
+		}
+	})
+
+	t.Run("start_point_error_for_existing_worktree_with_b_flag", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Create worktree first
+		runGitWt(t, binPath, repo.Root, "feature-branch")
+
+		// Switching to existing worktree with -b and start-point should error
+		_, _, err := runGitWtStdout(t, binPath, repo.Root, "feature-branch", "-b", "feature-branch", "main")
+		if err == nil {
+			t.Fatal("expected error when start-point is specified with -b for existing worktree, but got none")
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Return an error when `start-point` is specified but the target branch or worktree already exists, instead of silently ignoring it
- Covers both direct usage (`git wt existing-branch origin/main`) and `-b` flag usage (`git wt mydir -b existing-branch origin/main`)
- Updated E2E tests to verify the new error behavior (4 test cases)
