### PR TITLE
perf: batch branch commit-message lookups in shell completion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -348,6 +348,11 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 	// Track which names are worktrees
 	worktreeNames := make(map[string]struct{})
 
+	var commitMessages map[string]string
+	if msgs, err := git.BranchCommitMessages(ctx, "refs/heads"); err == nil {
+		commitMessages = msgs
+	}
+
 	// Add branches and directory names from existing worktrees
 	worktrees, err := git.ListWorktrees(ctx)
 	if err == nil {
@@ -373,12 +378,12 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 					// If worktree dir name matches branch name, use [worktree: branch=name] format
 					if wtDirName == wt.Branch {
 						desc = fmt.Sprintf("[worktree: branch=%s]", wt.Branch)
-						if msg, err := git.BranchCommitMessage(ctx, wt.Branch); err == nil && msg != "" {
+						if msg := commitMessages[wt.Branch]; msg != "" {
 							desc = fmt.Sprintf("[worktree: branch=%s] %s", wt.Branch, truncateString(msg, 40))
 						}
 					} else {
 						desc = fmt.Sprintf("[branch: worktree=%s]", wtInfo)
-						if msg, err := git.BranchCommitMessage(ctx, wt.Branch); err == nil && msg != "" {
+						if msg := commitMessages[wt.Branch]; msg != "" {
 							desc = fmt.Sprintf("[branch: worktree=%s] %s", wtInfo, truncateString(msg, 40))
 						}
 					}
@@ -399,12 +404,12 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 					// If worktree dir name matches branch name, use simpler [worktree: name] format
 					if wtDirName == branchInfo {
 						desc = fmt.Sprintf("[worktree: %s]", wtDirName)
-						if msg, err := git.BranchCommitMessage(ctx, wt.Branch); err == nil && msg != "" {
+						if msg := commitMessages[wt.Branch]; msg != "" {
 							desc = fmt.Sprintf("[worktree: %s] %s", wtDirName, truncateString(msg, 40))
 						}
 					} else {
 						desc = fmt.Sprintf("[worktree: branch=%s]", branchInfo)
-						if msg, err := git.BranchCommitMessage(ctx, wt.Branch); err == nil && msg != "" {
+						if msg := commitMessages[wt.Branch]; msg != "" {
 							desc = fmt.Sprintf("[worktree: branch=%s] %s", branchInfo, truncateString(msg, 40))
 						}
 					}
@@ -421,7 +426,7 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 			if _, exists := seen[branch]; !exists {
 				seen[branch] = struct{}{}
 				desc := "[branch]"
-				if msg, err := git.BranchCommitMessage(ctx, branch); err == nil && msg != "" {
+				if msg := commitMessages[branch]; msg != "" {
 					desc = "[branch] " + truncateString(msg, 40)
 				}
 				completions = append(completions, fmt.Sprintf("%s\t%s", branch, desc))
@@ -438,6 +443,11 @@ func completeStartPoint(ctx context.Context) ([]string, cobra.ShellCompDirective
 	seen := make(map[string]struct{})
 	var completions []string
 
+	var commitMessages map[string]string
+	if msgs, err := git.BranchCommitMessages(ctx, "refs/heads", "refs/remotes"); err == nil {
+		commitMessages = msgs
+	}
+
 	// Add local branches
 	branches, err := git.ListBranches(ctx)
 	if err == nil {
@@ -445,7 +455,7 @@ func completeStartPoint(ctx context.Context) ([]string, cobra.ShellCompDirective
 			if _, exists := seen[branch]; !exists {
 				seen[branch] = struct{}{}
 				desc := "[branch]"
-				if msg, err := git.BranchCommitMessage(ctx, branch); err == nil && msg != "" {
+				if msg := commitMessages[branch]; msg != "" {
 					desc = "[branch] " + truncateString(msg, 40)
 				}
 				completions = append(completions, fmt.Sprintf("%s\t%s", branch, desc))
@@ -460,7 +470,7 @@ func completeStartPoint(ctx context.Context) ([]string, cobra.ShellCompDirective
 			if _, exists := seen[branch]; !exists {
 				seen[branch] = struct{}{}
 				desc := "[remote]"
-				if msg, err := git.BranchCommitMessage(ctx, branch); err == nil && msg != "" {
+				if msg := commitMessages[branch]; msg != "" {
 					desc = "[remote] " + truncateString(msg, 40)
 				}
 				completions = append(completions, fmt.Sprintf("%s\t%s", branch, desc))

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -125,17 +125,27 @@ func ListBranches(ctx context.Context) ([]string, error) {
 	return branches, nil
 }
 
-// BranchCommitMessage returns the first line of the latest commit message for a branch.
-func BranchCommitMessage(ctx context.Context, branch string) (string, error) {
-	cmd, err := gitCommand(ctx, "log", "-1", "--format=%s", branch, "--")
+// BranchCommitMessages returns the first line of the latest commit message for each ref matching
+// the given for-each-ref patterns, keyed by short ref name (e.g. "main", "origin/main").
+func BranchCommitMessages(ctx context.Context, patterns ...string) (map[string]string, error) {
+	args := append([]string{"for-each-ref", "--format=%(refname:short)%00%(contents:subject)"}, patterns...)
+	cmd, err := gitCommand(ctx, args...)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return strings.TrimSpace(string(out)), nil
+	m := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		name, subject, _ := strings.Cut(line, "\x00")
+		m[name] = subject
+	}
+	return m, nil
 }
 
 // ListRemoteBranches returns a list of all remote branch names (e.g., origin/main).

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/k1LoW/git-wt/testutil"
@@ -101,6 +102,64 @@ func TestListBranches(t *testing.T) {
 		if !found {
 			t.Errorf("expected branch %q not found in list", name)
 		}
+	}
+}
+
+func TestBranchCommitMessages(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	repo.CreateFile("README.md", "# Test")
+	repo.Commit("initial commit")
+
+	repo.Git("checkout", "-b", "feature-a")
+	repo.CreateFile("a.txt", "a")
+	// Subject + body — only the subject should be returned.
+	repo.Commit("feature a subject\n\nbody line")
+
+	// Simulate a remote-tracking branch by writing directly under refs/remotes/origin.
+	sha := strings.TrimSpace(repo.Git("rev-parse", "feature-a"))
+	repo.Git("update-ref", "refs/remotes/origin/feature-a", sha)
+
+	repo.Git("checkout", "main")
+
+	restore := repo.Chdir()
+	defer restore()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     map[string]string
+	}{
+		{
+			name:     "local only",
+			patterns: []string{"refs/heads"},
+			want: map[string]string{
+				"main":      "initial commit",
+				"feature-a": "feature a subject",
+			},
+		},
+		{
+			name:     "local and remote",
+			patterns: []string{"refs/heads", "refs/remotes"},
+			want: map[string]string{
+				"main":             "initial commit",
+				"feature-a":        "feature a subject",
+				"origin/feature-a": "feature a subject",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BranchCommitMessages(t.Context(), tt.patterns...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for name, subject := range tt.want {
+				if got[name] != subject {
+					t.Errorf("BranchCommitMessages()[%q] = %q, want %q", name, got[name], subject)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`git wt`'s shell completion previously forked `git log -1` once per branch to fetch each branch's commit subject, which became slow in repositories with many local or remote-tracking branches. This change batches the lookup into a single `git for-each-ref` call. In a 500-branch reproduction, completion drops from ~2.2s to ~0.12s (~20x faster).

## Reproduction

The reproduction below uses local branches only for simplicity. `git-wt` is the released binary and `git-wt-fixed` is built from this branch.

```sh
tmp=$(mktemp -d) && cd "$tmp"
git init -q && git commit -q --allow-empty -m init
for i in $(seq 1 500); do git branch "b-$i"; done

time git-wt __complete "" >/dev/null
```
```
Completion ended with directive: ShellCompDirectiveNoFileComp
git-wt __complete "" > /dev/null  1.01s user 0.88s system 84% cpu 2.227 total
```

With the fix applied:

```sh
time git-wt-fixed __complete "" >/dev/null
```
```
Completion ended with directive: ShellCompDirectiveNoFileComp
git-wt-fixed __complete "" > /dev/null  0.05s user 0.06s system 87% cpu 0.119 total
```

I confirmed the completion output is identical before/after.

```sh
diff <(git-wt __complete "" 2>/dev/null) <(git-wt-fixed __complete "" 2>/dev/null)
# (no output → outputs are identical)
```
