### PR TITLE
feat: add `-m`/`-M` flag to rename a worktree's directory and branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ $ git wt <branch|worktree|path>     # Switch to worktree (create worktree/branch
 $ git wt -b <branch> <worktree>     # Create worktree with a different branch name
 $ git wt -d <branch|worktree|path>  # Delete worktree and branch (safe)
 $ git wt -D <branch|worktree|path>  # Force delete worktree and branch
+$ git wt -m [<old>] <new>           # Rename worktree directory and branch (safe)
+$ git wt -M [<old>] <new>           # Force rename (allow overwriting target / dirty worktree)
 ```
 
 The target can be specified as:
@@ -19,6 +21,15 @@ The target can be specified as:
 - **path**: a filesystem path (absolute or relative to the current working directory) to an existing worktree —  _eg._ `git wt ../sibling`, `git wt /absolute/path`
 
 When deleting, the same target types apply: `git wt -d feature-branch`, `git wt -d .`, `git wt -d ../sibling`
+
+Use `-m` (`-M` to force) to rename a worktree's directory and branch in a single operation. With one argument, the current worktree is renamed; with two, an explicit worktree is renamed:
+
+``` console
+$ git wt -m new-name                 # rename the current worktree to "new-name"
+$ git wt -m old-name new-name        # rename worktree "old-name" to "new-name"
+```
+
+When invoked through the shell integration on the current worktree, the shell wrapper `cd`s to the new path (the same way `-d` returns to the main repository root after deleting the current worktree).
 
 Use `-b`/`--branch` to give the branch a different name from the worktree directory:
 
@@ -34,10 +45,10 @@ $ git wt my-feature       # switch by directory name
 ```
 
 > [!NOTE]
-> The default branch (e.g., main, master) is protected from accidental deletion.
-> - If the default branch has a worktree, the worktree is deleted but the branch is preserved.
+> The default branch (e.g., main, master) is protected from accidental deletion or rename.
+> - If the default branch has a worktree, `-d` removes the worktree but keeps the branch; `-m`/`-M` is blocked entirely.
 > - If the default branch has no worktree, deletion is blocked entirely.
-> - Use `--allow-delete-default` to override this protection and delete the branch.
+> - Use `--allow-delete-default` to override this protection and delete or rename the branch.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ git wt -b <branch> <worktree>     # Create worktree with a different branch na
 $ git wt -d <branch|worktree|path>  # Delete worktree and branch (safe)
 $ git wt -D <branch|worktree|path>  # Force delete worktree and branch
 $ git wt -m [<old>] <new>           # Rename worktree directory and branch (safe)
-$ git wt -M [<old>] <new>           # Force rename (allow overwriting target / dirty worktree)
+$ git wt -M [<old>] <new>           # Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 ```
 
 The target can be specified as:

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ $ git wt my-feature       # switch by directory name
 ```
 
 > [!NOTE]
-> The default branch (e.g., main, master) is protected from accidental deletion or rename.
-> - If the default branch has a worktree, `-d` removes the worktree but keeps the branch; `-m`/`-M` is blocked entirely.
-> - If the default branch has no worktree, deletion is blocked entirely.
-> - Use `--allow-delete-default` to override this protection and delete or rename the branch.
+> The default branch (e.g., main, master) is protected from accidental deletion or rename. Pass `--allow-delete-default` to override the protection.
+> - If the default branch has a worktree, `-d` removes the worktree but keeps the branch by default; `-m`/`-M` refuses to rename it by default.
+> - If the default branch has no worktree, deletion is refused by default.
+> - In every case, `--allow-delete-default` lifts the protection and lets the destructive operation proceed against the default branch.
 
 ## Install
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -14,6 +14,7 @@ git() {
         shift
         local nocd_mode=""
         local nocd_flag=false
+        local rename_flag=false
         # Check wt.nocd config (supports: true, all, create, false)
         nocd_mode="$(command git config --get wt.nocd 2>/dev/null || true)"
         local existing_worktrees=""
@@ -25,6 +26,9 @@ git() {
         for arg in "$@"; do
             if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
                 nocd_flag=true
+            fi
+            if [[ "$arg" == "-m" || "$arg" == "-M" || "$arg" == "--move" || "$arg" == "--force-move" ]]; then
+                rename_flag=true
             fi
             args+=("$arg")
         done
@@ -49,7 +53,9 @@ git() {
                 should_cd=false
             elif [[ "$nocd_mode" == "create" ]]; then
                 # wt.nocd=create only prevents cd for new worktrees
-                if echo "$existing_worktrees" | grep -qxF "$last_line"; then
+                if [[ "$rename_flag" == "true" ]]; then
+                    should_cd=true  # rename targets existing worktree at new path
+                elif echo "$existing_worktrees" | grep -qxF "$last_line"; then
                     should_cd=true  # existing worktree, allow cd
                 else
                     should_cd=false  # new worktree, prevent cd
@@ -94,6 +100,7 @@ git() {
         shift
         local nocd_mode=""
         local nocd_flag=false
+        local rename_flag=false
         # Check wt.nocd config (supports: true, all, create, false)
         nocd_mode="$(command git config --get wt.nocd 2>/dev/null || true)"
         local existing_worktrees=""
@@ -105,6 +112,9 @@ git() {
         for arg in "$@"; do
             if [[ "$arg" == "--nocd" || "$arg" == "--no-switch-directory" ]]; then
                 nocd_flag=true
+            fi
+            if [[ "$arg" == "-m" || "$arg" == "-M" || "$arg" == "--move" || "$arg" == "--force-move" ]]; then
+                rename_flag=true
             fi
             args+=("$arg")
         done
@@ -129,7 +139,9 @@ git() {
                 should_cd=false
             elif [[ "$nocd_mode" == "create" ]]; then
                 # wt.nocd=create only prevents cd for new worktrees
-                if echo "$existing_worktrees" | grep -qxF "$last_line"; then
+                if [[ "$rename_flag" == "true" ]]; then
+                    should_cd=true  # rename targets existing worktree at new path
+                elif echo "$existing_worktrees" | grep -qxF "$last_line"; then
                     should_cd=true  # existing worktree, allow cd
                 else
                     should_cd=false  # new worktree, prevent cd
@@ -193,6 +205,7 @@ const fishGitWrapper = `
 function git --wraps git
     if test "$argv[1]" = "wt"
         set -l nocd_flag false
+        set -l rename_flag false
         # Check wt.nocd config (supports: true, all, create, false)
         set -l nocd_mode (command git config --get wt.nocd 2>/dev/null)
         set -l existing_worktrees
@@ -203,7 +216,9 @@ function git --wraps git
         for arg in $argv[2..]
             if string match -q -- "--nocd" "$arg"; or string match -q -- "--no-switch-directory" "$arg"
                 set nocd_flag true
-                break
+            end
+            if string match -q -- "-m" "$arg"; or string match -q -- "-M" "$arg"; or string match -q -- "--move" "$arg"; or string match -q -- "--force-move" "$arg"
+                set rename_flag true
             end
         end
         set -lx GIT_WT_SHELL_INTEGRATION 1
@@ -226,7 +241,9 @@ function git --wraps git
                 set should_cd false
             else if test "$nocd_mode" = "create"
                 # wt.nocd=create only prevents cd for new worktrees
-                if contains -- "$last_line" $existing_worktrees
+                if test "$rename_flag" = "true"
+                    set should_cd true  # rename targets existing worktree at new path
+                else if contains -- "$last_line" $existing_worktrees
                     set should_cd true  # existing worktree, allow cd
                 else
                     set should_cd false  # new worktree, prevent cd
@@ -287,6 +304,7 @@ const powershellGitWrapper = "" +
 	"    if ($args[0] -eq \"wt\") {\n" +
 	"        $wtArgs = $args[1..($args.Length-1)]\n" +
 	"        $nocdFlag = ($wtArgs -contains \"--nocd\") -or ($wtArgs -contains \"--no-switch-directory\")\n" +
+	"        $renameFlag = ($wtArgs -contains \"-m\") -or ($wtArgs -contains \"-M\") -or ($wtArgs -contains \"--move\") -or ($wtArgs -contains \"--force-move\")\n" +
 	"        # Check wt.nocd config (supports: true, all, create, false)\n" +
 	"        $nocdMode = & git.exe config --get wt.nocd 2>$null\n" +
 	"        $existingWorktrees = @()\n" +
@@ -315,7 +333,9 @@ const powershellGitWrapper = "" +
 	"                $shouldCd = $false\n" +
 	"            } elseif ($nocdMode -eq \"create\") {\n" +
 	"                # wt.nocd=create only prevents cd for new worktrees\n" +
-	"                if ($existingWorktrees -contains $lastLine) {\n" +
+	"                if ($renameFlag) {\n" +
+	"                    $shouldCd = $true  # rename targets existing worktree at new path\n" +
+	"                } elseif ($existingWorktrees -contains $lastLine) {\n" +
 	"                    $shouldCd = $true  # existing worktree, allow cd\n" +
 	"                } else {\n" +
 	"                    $shouldCd = $false  # new worktree, prevent cd\n" +

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -956,9 +956,12 @@ func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force 
 	}
 
 	// User-facing message.
-	if src.Branch == newName {
+	switch {
+	case src.Branch == newName:
 		fmt.Fprintf(os.Stderr, "Moved worktree to %q\n", newPath)
-	} else {
+	case samePath:
+		fmt.Fprintf(os.Stderr, "Renamed branch %q to %q (worktree directory unchanged)\n", src.Branch, newName)
+	default:
 		fmt.Fprintf(os.Stderr, "Renamed worktree to %q and branch to %q\n", newPath, newName)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -344,8 +344,15 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 	ctx := cmd.Context()
 
 	// For second argument (start-point), complete with branches including remote
-	if len(args) == 1 && !deleteFlag && !forceDeleteFlag {
+	if len(args) == 1 && !deleteFlag && !forceDeleteFlag && !moveFlag && !forceMoveFlag {
 		return completeStartPoint(ctx)
+	}
+
+	// Under -m/-M, the second positional is the *new name* (free text),
+	// not a ref. Offer no completions there so the user is not misled into
+	// picking an existing branch.
+	if len(args) >= 1 && (moveFlag || forceMoveFlag) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// For delete flags, allow multiple arguments (same completion as first arg)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -827,6 +827,32 @@ func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force 
 		return fmt.Errorf("cannot rename worktree at %q: it has no branch (detached HEAD)", src.Path)
 	}
 
+	// Reject the main working tree explicitly. The 1-arg form already blocks
+	// this via rc.IsLinkedWorktree(), but the 2-arg form can resolve the
+	// main worktree (e.g. `git wt -m . new`, or by passing its path), so
+	// guard at the post-resolve stage too. `git worktree move` refuses the
+	// main worktree as well, but its error is opaque; surfacing the reason
+	// here matches the documented contract that the main working tree
+	// cannot be renamed via this command.
+	mainRoot, err := git.MainRepoRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get main repository root: %w", err)
+	}
+	resolvedMainRoot := mainRoot
+	if resolved, err := filepath.EvalSymlinks(mainRoot); err == nil {
+		resolvedMainRoot = resolved
+	}
+	resolvedSrcPath, err := filepath.Abs(src.Path)
+	if err != nil {
+		return fmt.Errorf("failed to resolve source worktree path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(resolvedSrcPath); err == nil {
+		resolvedSrcPath = resolved
+	}
+	if resolvedSrcPath == resolvedMainRoot {
+		return fmt.Errorf("cannot rename the main working tree at %q via this command", src.Path)
+	}
+
 	// Protect the default branch unless overridden.
 	isDefault, err := git.IsDefaultBranch(ctx, src.Branch)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ Examples:
   git wt -d <branch|worktree|path>...            Delete worktree and branch (safe)
   git wt -D <branch|worktree|path>...            Force delete worktree and branch
   git wt -m [<old>] <new>                        Rename worktree directory and branch (safe)
-  git wt -M [<old>] <new>                        Force rename (allow overwriting target / dirty worktree)
+  git wt -M [<old>] <new>                        Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 
 Note: The default branch (e.g., main, master) is protected from accidental deletion or rename.
       - With worktree: -d removes the worktree but keeps the branch; -m/-M is blocked entirely.
@@ -198,7 +198,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch by name or path (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch by name or path")
 	rootCmd.Flags().BoolVarP(&moveFlag, "move", "m", false, "Rename worktree directory and branch (safe rename)")
-	rootCmd.Flags().BoolVarP(&forceMoveFlag, "force-move", "M", false, "Force rename worktree directory and branch (allow overwriting existing target)")
+	rootCmd.Flags().BoolVarP(&forceMoveFlag, "force-move", "M", false, "Force rename worktree directory and branch (allow overwriting existing branch and moving dirty/locked worktrees)")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
 	rootCmd.Flags().BoolVar(&nocd, "nocd", false, "Do not change directory to the worktree (also disables git() wrapper when used with --init)")
 	rootCmd.Flags().BoolVar(&nocd, "no-switch-directory", false, "")
@@ -841,23 +841,34 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 		return fmt.Errorf("worktree %q is already named %q", src.Branch, newName)
 	}
 
-	// Pre-flight checks for target collisions (git worktree move / branch -m also catch these,
-	// but checking up front lets us return a clearer error and avoids partial state).
-	if !force {
-		if info, err := os.Stat(newPath); err == nil {
-			if info.IsDir() {
-				return fmt.Errorf("target worktree directory %q already exists (use -M to force)", newPath)
-			}
-			return fmt.Errorf("target path %q exists and is not a directory", newPath)
+	// Validate the new branch name BEFORE touching the filesystem. Otherwise
+	// `git worktree move` can succeed and `git branch -m` then fail on an
+	// invalid name (e.g., "foo..bar"), leaving a worktree directory renamed
+	// while the branch is still on the old name.
+	if src.Branch != newName {
+		if err := git.CheckBranchNameFormat(ctx, newName); err != nil {
+			return err
 		}
-		if src.Branch != newName {
-			exists, err := git.LocalBranchExists(ctx, newName)
-			if err != nil {
-				return fmt.Errorf("failed to check branch existence: %w", err)
-			}
-			if exists {
-				return fmt.Errorf("branch %q already exists (use -M to force)", newName)
-			}
+	}
+
+	// Pre-flight checks for target collisions. Branch collisions are skipped
+	// under -M because `git branch -M` can overwrite a target branch; target
+	// directory collisions are checked unconditionally because `git worktree
+	// move --force` does NOT overwrite an existing destination — its --force
+	// only relaxes dirty/locked-worktree checks.
+	if info, err := os.Stat(newPath); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("target worktree directory %q already exists", newPath)
+		}
+		return fmt.Errorf("target path %q exists and is not a directory", newPath)
+	}
+	if !force && src.Branch != newName {
+		exists, err := git.LocalBranchExists(ctx, newName)
+		if err != nil {
+			return fmt.Errorf("failed to check branch existence: %w", err)
+		}
+		if exists {
+			return fmt.Errorf("branch %q already exists (use -M to force)", newName)
 		}
 	}
 
@@ -869,11 +880,6 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 			curWt = resolved
 		}
 		inside = curWt == oldPath
-	}
-
-	mainRoot, err := git.MainRepoRoot(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get main repository root: %w", err)
 	}
 
 	// Move the directory first. Skip when source and target paths are identical
@@ -909,7 +915,6 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 	// path so the shell wrapper can cd there. The shell wrapper inspects
 	// -m/-M to keep this consistent with wt.nocd=create (existing worktree,
 	// not a fresh creation).
-	_ = mainRoot
 	if inside && os.Getenv("GIT_WT_SHELL_INTEGRATION") == "1" {
 		fmt.Println(newPath)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -271,7 +271,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		if branchFlag != "" {
 			return fmt.Errorf("cannot use -b/--branch with -m/-M")
 		}
-		return moveWorktree(ctx, args, forceMoveFlag)
+		return moveWorktree(ctx, cmd, args, forceMoveFlag)
 	}
 
 	// For create/switch: validate argument count (like git branch)
@@ -751,7 +751,7 @@ func deleteWorktrees(ctx context.Context, cmd *cobra.Command, branches []string,
 // moveWorktree renames a worktree's directory and its associated branch in
 // a single operation. It accepts either one argument (the new name, applied
 // to the current worktree) or two arguments (old, new).
-func moveWorktree(ctx context.Context, args []string, force bool) error {
+func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force bool) error {
 	if len(args) == 0 || len(args) > 2 {
 		return fmt.Errorf("expected 1 or 2 arguments for -m/-M: <newname> or <oldname> <newname>, got %d", len(args))
 	}
@@ -764,7 +764,7 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 		newName = args[1]
 	}
 
-	cfg, err := git.LoadConfig(ctx)
+	cfg, err := loadConfig(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -855,12 +855,22 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 	// under -M because `git branch -M` can overwrite a target branch; target
 	// directory collisions are checked unconditionally because `git worktree
 	// move --force` does NOT overwrite an existing destination — its --force
-	// only relaxes dirty/locked-worktree checks.
-	if info, err := os.Stat(newPath); err == nil {
-		if info.IsDir() {
-			return fmt.Errorf("target worktree directory %q already exists", newPath)
+	// only relaxes dirty/locked-worktree checks. The check is also skipped
+	// when newPath resolves to the same directory as oldPath (the
+	// branch-only rename case, e.g. a worktree created via `-b` whose
+	// directory is already named newName).
+	samePath := oldPath == filepath.Clean(newPath)
+	if !samePath {
+		info, err := os.Stat(newPath)
+		switch {
+		case err == nil:
+			if info.IsDir() {
+				return fmt.Errorf("target worktree directory %q already exists", newPath)
+			}
+			return fmt.Errorf("target path %q exists and is not a directory", newPath)
+		case !os.IsNotExist(err):
+			return fmt.Errorf("failed to stat target path %q: %w", newPath, err)
 		}
-		return fmt.Errorf("target path %q exists and is not a directory", newPath)
 	}
 	if !force && src.Branch != newName {
 		exists, err := git.LocalBranchExists(ctx, newName)
@@ -882,9 +892,9 @@ func moveWorktree(ctx context.Context, args []string, force bool) error {
 		inside = curWt == oldPath
 	}
 
-	// Move the directory first. Skip when source and target paths are identical
-	// (only the branch changes).
-	if oldPath != filepath.Clean(newPath) {
+	// Move the directory first. Skip when source and target paths are
+	// identical (only the branch changes).
+	if !samePath {
 		if err := git.MoveWorktree(ctx, oldPath, newPath, force); err != nil {
 			return fmt.Errorf("failed to move worktree: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,8 @@ import (
 var (
 	deleteFlag      bool
 	forceDeleteFlag bool
+	moveFlag        bool
+	forceMoveFlag   bool
 	initShell       string
 	nocd            bool
 	branchFlag      string
@@ -69,11 +71,13 @@ Examples:
   git wt -b <branch> <worktree>                  Create worktree with a different branch name
   git wt -d <branch|worktree|path>...            Delete worktree and branch (safe)
   git wt -D <branch|worktree|path>...            Force delete worktree and branch
+  git wt -m [<old>] <new>                        Rename worktree directory and branch (safe)
+  git wt -M [<old>] <new>                        Force rename (allow overwriting target / dirty worktree)
 
-Note: The default branch (e.g., main, master) is protected from accidental deletion.
-      - With worktree: worktree is deleted, but branch is preserved.
+Note: The default branch (e.g., main, master) is protected from accidental deletion or rename.
+      - With worktree: -d removes the worktree but keeps the branch; -m/-M is blocked entirely.
       - Without worktree: deletion is blocked entirely.
-      Use --allow-delete-default to override and delete the branch.
+      Use --allow-delete-default to override and delete or rename the branch.
 
 Shell Integration:
   Add the following to your shell config to enable worktree switching and completion:
@@ -193,6 +197,8 @@ func init() {
 
 	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch by name or path (safe delete, only if merged)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch by name or path")
+	rootCmd.Flags().BoolVarP(&moveFlag, "move", "m", false, "Rename worktree directory and branch (safe rename)")
+	rootCmd.Flags().BoolVarP(&forceMoveFlag, "force-move", "M", false, "Force rename worktree directory and branch (allow overwriting existing target)")
 	rootCmd.Flags().StringVar(&initShell, "init", "", "Output shell initialization script (bash, zsh, fish, powershell)")
 	rootCmd.Flags().BoolVar(&nocd, "nocd", false, "Do not change directory to the worktree (also disables git() wrapper when used with --init)")
 	rootCmd.Flags().BoolVar(&nocd, "no-switch-directory", false, "")
@@ -243,6 +249,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		if branchFlag != "" {
 			return fmt.Errorf("cannot use -b/--branch with -D/--force-delete")
 		}
+		if moveFlag || forceMoveFlag {
+			return fmt.Errorf("cannot combine -m/-M with -d/-D")
+		}
 		args = uniqueArgs(args)
 		return deleteWorktrees(ctx, cmd, args, true)
 	}
@@ -250,8 +259,19 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		if branchFlag != "" {
 			return fmt.Errorf("cannot use -b/--branch with -d/--delete")
 		}
+		if moveFlag || forceMoveFlag {
+			return fmt.Errorf("cannot combine -m/-M with -d/-D")
+		}
 		args = uniqueArgs(args)
 		return deleteWorktrees(ctx, cmd, args, false)
+	}
+
+	// Handle move/rename flags
+	if moveFlag || forceMoveFlag {
+		if branchFlag != "" {
+			return fmt.Errorf("cannot use -b/--branch with -m/-M")
+		}
+		return moveWorktree(ctx, args, forceMoveFlag)
 	}
 
 	// For create/switch: validate argument count (like git branch)
@@ -725,6 +745,174 @@ func deleteWorktrees(ctx context.Context, cmd *cobra.Command, branches []string,
 		fmt.Println(mainRoot)
 	}
 
+	return nil
+}
+
+// moveWorktree renames a worktree's directory and its associated branch in
+// a single operation. It accepts either one argument (the new name, applied
+// to the current worktree) or two arguments (old, new).
+func moveWorktree(ctx context.Context, args []string, force bool) error {
+	if len(args) == 0 || len(args) > 2 {
+		return fmt.Errorf("expected 1 or 2 arguments for -m/-M: <newname> or <oldname> <newname>, got %d", len(args))
+	}
+
+	var oldQuery, newName string
+	if len(args) == 1 {
+		newName = args[0]
+	} else {
+		oldQuery = args[0]
+		newName = args[1]
+	}
+
+	cfg, err := git.LoadConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	baseDir, err := git.ExpandBaseDir(ctx, cfg.BaseDir)
+	if err != nil {
+		return fmt.Errorf("failed to expand basedir: %w", err)
+	}
+	// Resolve symlinks for reliable path comparison (macOS /var vs /private/var).
+	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
+		baseDir = resolved
+	}
+
+	// Resolve source worktree.
+	var src *git.Worktree
+	if oldQuery == "" {
+		// Single-argument form: rename the current linked worktree. The main
+		// working tree cannot be renamed via this command.
+		rc, err := git.DetectRepoContext(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to detect repository context: %w", err)
+		}
+		if !rc.IsLinkedWorktree() {
+			return fmt.Errorf("current directory is not a linked worktree; specify the worktree to rename explicitly")
+		}
+		cur, err := git.CurrentWorktree(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get current worktree: %w", err)
+		}
+		src, err = git.FindWorktreeByBranchOrDir(ctx, cur)
+		if err != nil {
+			return fmt.Errorf("failed to find current worktree: %w", err)
+		}
+		if src == nil {
+			return fmt.Errorf("current directory is not a linked worktree; specify the worktree to rename explicitly")
+		}
+	} else {
+		src, err = git.FindWorktreeByBranchOrDir(ctx, oldQuery)
+		if err != nil {
+			return fmt.Errorf("failed to find worktree: %w", err)
+		}
+		if src == nil {
+			return fmt.Errorf("no worktree found for %q", oldQuery)
+		}
+	}
+
+	if src.Branch == "" || src.Branch == git.DetachedMarker {
+		return fmt.Errorf("cannot rename worktree at %q: it has no branch (detached HEAD)", src.Path)
+	}
+
+	// Protect the default branch unless overridden.
+	isDefault, err := git.IsDefaultBranch(ctx, src.Branch)
+	if err != nil {
+		return fmt.Errorf("failed to check default branch: %w", err)
+	}
+	if isDefault && !allowDeleteDefault {
+		return fmt.Errorf("cannot rename default branch %q: use --allow-delete-default to override", src.Branch)
+	}
+
+	// Resolve old and new paths.
+	oldPath, err := filepath.Abs(src.Path)
+	if err != nil {
+		return fmt.Errorf("failed to resolve old worktree path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(oldPath); err == nil {
+		oldPath = resolved
+	}
+
+	newPath, err := git.WorktreePathFor(ctx, cfg.BaseDir, newName)
+	if err != nil {
+		return fmt.Errorf("failed to compute new worktree path: %w", err)
+	}
+
+	if oldPath == filepath.Clean(newPath) && src.Branch == newName {
+		return fmt.Errorf("worktree %q is already named %q", src.Branch, newName)
+	}
+
+	// Pre-flight checks for target collisions (git worktree move / branch -m also catch these,
+	// but checking up front lets us return a clearer error and avoids partial state).
+	if !force {
+		if info, err := os.Stat(newPath); err == nil {
+			if info.IsDir() {
+				return fmt.Errorf("target worktree directory %q already exists (use -M to force)", newPath)
+			}
+			return fmt.Errorf("target path %q exists and is not a directory", newPath)
+		}
+		if src.Branch != newName {
+			exists, err := git.LocalBranchExists(ctx, newName)
+			if err != nil {
+				return fmt.Errorf("failed to check branch existence: %w", err)
+			}
+			if exists {
+				return fmt.Errorf("branch %q already exists (use -M to force)", newName)
+			}
+		}
+	}
+
+	// Detect whether we are currently inside the worktree being renamed.
+	curWt, _ := git.CurrentWorktree(ctx) //nostyle:handlerrors
+	inside := false
+	if curWt != "" {
+		if resolved, err := filepath.EvalSymlinks(curWt); err == nil {
+			curWt = resolved
+		}
+		inside = curWt == oldPath
+	}
+
+	mainRoot, err := git.MainRepoRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get main repository root: %w", err)
+	}
+
+	// Move the directory first. Skip when source and target paths are identical
+	// (only the branch changes).
+	if oldPath != filepath.Clean(newPath) {
+		if err := git.MoveWorktree(ctx, oldPath, newPath, force); err != nil {
+			return fmt.Errorf("failed to move worktree: %w", err)
+		}
+		// Clean up now-empty parent directories under basedir (e.g., the "feat/"
+		// left behind when renaming "feat/foo" out of basedir/feat/foo).
+		oldParent := filepath.Dir(oldPath)
+		if err := git.RemoveEmptyParents(oldParent, baseDir); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to clean up empty parent directories: %v\n", err)
+		}
+	}
+
+	// Rename the branch. Run from the new worktree path so the command works
+	// even when the old cwd has just been removed.
+	if src.Branch != newName {
+		if err := git.RenameBranch(ctx, src.Branch, newName, force, newPath); err != nil {
+			return fmt.Errorf("failed to rename branch: %w", err)
+		}
+	}
+
+	// User-facing message.
+	if src.Branch == newName {
+		fmt.Fprintf(os.Stderr, "Moved worktree to %q\n", newPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Renamed worktree to %q and branch to %q\n", newPath, newName)
+	}
+
+	// Shell integration: when the current worktree was renamed, print the new
+	// path so the shell wrapper can cd there. The shell wrapper inspects
+	// -m/-M to keep this consistent with wt.nocd=create (existing worktree,
+	// not a fresh creation).
+	_ = mainRoot
+	if inside && os.Getenv("GIT_WT_SHELL_INTEGRATION") == "1" {
+		fmt.Println(newPath)
+	}
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -806,7 +806,20 @@ func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force 
 			return fmt.Errorf("failed to find worktree: %w", err)
 		}
 		if src == nil {
-			return fmt.Errorf("no worktree found for %q", oldQuery)
+			// Fallback: try matching <oldQuery> as a directory name relative
+			// to the already-resolved (override-aware) baseDir.
+			// FindWorktreeByBranchOrDir uses internal git.LoadConfig for its
+			// basedir-relative match path, so a `--basedir` flag override
+			// does not reach it. Resolving to an absolute path here lets the
+			// helper's path-matching strategy pick the worktree up.
+			candidate := filepath.Join(baseDir, oldQuery)
+			src, err = git.FindWorktreeByBranchOrDir(ctx, candidate)
+			if err != nil {
+				return fmt.Errorf("failed to find worktree: %w", err)
+			}
+			if src == nil {
+				return fmt.Errorf("no worktree found for %q", oldQuery)
+			}
 		}
 	}
 
@@ -832,12 +845,14 @@ func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force 
 		oldPath = resolved
 	}
 
-	newPath, err := git.WorktreePathFor(ctx, cfg.BaseDir, newName)
-	if err != nil {
-		return fmt.Errorf("failed to compute new worktree path: %w", err)
-	}
+	// Build newPath off the already-symlink-resolved baseDir so the prefix
+	// matches oldPath (also symlink-resolved). Going through
+	// git.WorktreePathFor here would re-expand cfg.BaseDir without resolving
+	// symlinks, leaving newPath at e.g. /var/... while oldPath is
+	// /private/var/... on macOS — which silently breaks the samePath check.
+	newPath := filepath.Clean(filepath.Join(baseDir, newName))
 
-	if oldPath == filepath.Clean(newPath) && src.Branch == newName {
+	if oldPath == newPath && src.Branch == newName {
 		return fmt.Errorf("worktree %q is already named %q", src.Branch, newName)
 	}
 
@@ -859,7 +874,7 @@ func moveWorktree(ctx context.Context, cmd *cobra.Command, args []string, force 
 	// when newPath resolves to the same directory as oldPath (the
 	// branch-only rename case, e.g. a worktree created via `-b` whose
 	// directory is already named newName).
-	samePath := oldPath == filepath.Clean(newPath)
+	samePath := oldPath == newPath
 	if !samePath {
 		info, err := os.Stat(newPath)
 		switch {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,9 +75,9 @@ Examples:
   git wt -M [<old>] <new>                        Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 
 Note: The default branch (e.g., main, master) is protected from accidental deletion or rename.
-      - With worktree: -d removes the worktree but keeps the branch; -m/-M is blocked entirely.
-      - Without worktree: deletion is blocked entirely.
-      Use --allow-delete-default to override and delete or rename the branch.
+      Pass --allow-delete-default to override the protection in any of the cases below.
+      - With worktree: -d removes the worktree but keeps the branch by default; -m/-M refuses to rename by default.
+      - Without worktree: deletion is refused by default.
 
 Shell Integration:
   Add the following to your shell config to enable worktree switching and completion:

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -1,0 +1,465 @@
+// move_test.go contains worktree rename tests:
+//   - TestE2E_MoveWorktree: -m/-M renaming (basic, force, conflicts, default branch, slash branches)
+//   - TestE2E_MoveCurrentWorktree: renaming the worktree we are currently inside
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/exec"
+	"github.com/k1LoW/git-wt/testutil"
+)
+
+func TestE2E_MoveWorktree(t *testing.T) {
+	t.Parallel()
+	binPath := buildBinary(t)
+
+	t.Run("two_arg_rename", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "old-name")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v\noutput: %s", err, out)
+		}
+		oldPath := worktreePath(out)
+
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "old-name", "new-name")
+		if err != nil {
+			t.Fatalf("git-wt -m failed: %v\noutput: %s", err, out)
+		}
+
+		if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+			t.Errorf("old worktree directory should have been moved: %s", oldPath)
+		}
+		newPath := filepath.Join(filepath.Dir(oldPath), "new-name")
+		if _, err := os.Stat(newPath); err != nil {
+			t.Errorf("new worktree directory should exist at %s: %v", newPath, err)
+		}
+
+		cmd := exec.Command("git", "branch", "--list", "new-name")
+		cmd.Dir = repo.Root
+		branchOut, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list failed: %v", err)
+		}
+		if !strings.Contains(string(branchOut), "new-name") {
+			t.Errorf("new-name branch should exist, got: %s", branchOut)
+		}
+		cmd = exec.Command("git", "branch", "--list", "old-name")
+		cmd.Dir = repo.Root
+		branchOut, err = cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list failed: %v", err)
+		}
+		if strings.Contains(string(branchOut), "old-name") {
+			t.Errorf("old-name branch should have been renamed, still found: %s", branchOut)
+		}
+	})
+
+	t.Run("one_arg_renames_current", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "wt-cur")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v\noutput: %s", err, out)
+		}
+		oldPath := worktreePath(out)
+
+		out, err = runGitWt(t, binPath, oldPath, "-m", "wt-renamed")
+		if err != nil {
+			t.Fatalf("git-wt -m failed: %v\noutput: %s", err, out)
+		}
+
+		if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+			t.Errorf("old worktree directory should have been moved")
+		}
+		newPath := filepath.Join(filepath.Dir(oldPath), "wt-renamed")
+		if _, err := os.Stat(newPath); err != nil {
+			t.Errorf("renamed worktree directory should exist: %v", err)
+		}
+	})
+
+	t.Run("one_arg_fails_outside_worktree", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "something")
+		if err == nil {
+			t.Fatalf("should fail when run from main repo, got: %s", out)
+		}
+		if !strings.Contains(out, "not a linked worktree") {
+			t.Errorf("error should mention 'not a linked worktree', got: %s", out)
+		}
+	})
+
+	t.Run("target_dir_exists_blocks_safe", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		if _, err := runGitWt(t, binPath, repo.Root, "src"); err != nil {
+			t.Fatalf("failed to create worktree src: %v", err)
+		}
+		if _, err := runGitWt(t, binPath, repo.Root, "dst"); err != nil {
+			t.Fatalf("failed to create worktree dst: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "src", "dst")
+		if err == nil {
+			t.Fatalf("rename should fail when target dir exists, got: %s", out)
+		}
+		if !strings.Contains(out, "already exists") {
+			t.Errorf("error should mention 'already exists', got: %s", out)
+		}
+	})
+
+	t.Run("target_branch_exists_blocks_safe", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		if _, err := runGitWt(t, binPath, repo.Root, "src-only"); err != nil {
+			t.Fatalf("failed to create worktree src-only: %v", err)
+		}
+		// Create a branch (without a worktree) that the rename would collide with.
+		cmd := exec.Command("git", "branch", "taken")
+		cmd.Dir = repo.Root
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to create branch taken: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "src-only", "taken")
+		if err == nil {
+			t.Fatalf("rename should fail when target branch exists, got: %s", out)
+		}
+		if !strings.Contains(out, "already exists") {
+			t.Errorf("error should mention 'already exists', got: %s", out)
+		}
+	})
+
+	t.Run("force_overwrites_branch", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		if _, err := runGitWt(t, binPath, repo.Root, "src-force"); err != nil {
+			t.Fatalf("failed to create worktree src-force: %v", err)
+		}
+		// Create a branch that would collide; -M overrides via `git branch -M`.
+		cmd := exec.Command("git", "branch", "taken-force")
+		cmd.Dir = repo.Root
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to create branch: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-M", "src-force", "taken-force")
+		if err != nil {
+			t.Fatalf("git-wt -M should succeed: %v\noutput: %s", err, out)
+		}
+	})
+
+	t.Run("renames_branch_with_slash_and_cleans_parents", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "feat/slashy")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v\noutput: %s", err, out)
+		}
+		oldPath := worktreePath(out)
+		oldParent := filepath.Dir(oldPath)
+
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "feat/slashy", "flat")
+		if err != nil {
+			t.Fatalf("git-wt -m failed: %v\noutput: %s", err, out)
+		}
+
+		if _, err := os.Stat(oldParent); !os.IsNotExist(err) {
+			t.Errorf("empty parent directory should have been cleaned up: %s", oldParent)
+		}
+	})
+
+	t.Run("blocks_renaming_default_branch", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Switch off main so a worktree for main can be created.
+		cmd := exec.Command("git", "checkout", "-b", "side")
+		cmd.Dir = repo.Root
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to switch branch: %v", err)
+		}
+		if _, err := runGitWt(t, binPath, repo.Root, "main"); err != nil {
+			t.Fatalf("failed to create worktree for main: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "main", "trunk")
+		if err == nil {
+			t.Fatalf("renaming the default branch should fail without --allow-delete-default, got: %s", out)
+		}
+		if !strings.Contains(out, "default branch") {
+			t.Errorf("error should mention default branch, got: %s", out)
+		}
+	})
+
+	t.Run("allows_default_rename_with_override", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		cmd := exec.Command("git", "checkout", "-b", "side")
+		cmd.Dir = repo.Root
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to switch branch: %v", err)
+		}
+		if _, err := runGitWt(t, binPath, repo.Root, "main"); err != nil {
+			t.Fatalf("failed to create worktree for main: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "--allow-delete-default", "main", "trunk")
+		if err != nil {
+			t.Fatalf("rename with --allow-delete-default should succeed: %v\noutput: %s", err, out)
+		}
+
+		cmd = exec.Command("git", "branch", "--list", "trunk")
+		cmd.Dir = repo.Root
+		branchOut, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list failed: %v", err)
+		}
+		if !strings.Contains(string(branchOut), "trunk") {
+			t.Errorf("trunk branch should exist after rename, got: %s", branchOut)
+		}
+	})
+
+	t.Run("detached_head_blocked", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Add a worktree, then detach its HEAD.
+		out, err := runGitWt(t, binPath, repo.Root, "to-detach")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v\noutput: %s", err, out)
+		}
+		wtPath := worktreePath(out)
+		cmd := exec.Command("git", "checkout", "--detach")
+		cmd.Dir = wtPath
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to detach HEAD: %v", err)
+		}
+
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "to-detach", "anywhere")
+		if err == nil {
+			t.Fatalf("rename should fail on detached HEAD, got: %s", out)
+		}
+		if !strings.Contains(out, "detached HEAD") {
+			t.Errorf("error should mention detached HEAD, got: %s", out)
+		}
+	})
+
+	t.Run("rejects_b_flag", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		if _, err := runGitWt(t, binPath, repo.Root, "with-b"); err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "-b", "x", "with-b", "y")
+		if err == nil {
+			t.Fatalf("-m with -b should fail, got: %s", out)
+		}
+	})
+
+	t.Run("rejects_three_args", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "-m", "a", "b", "c")
+		if err == nil {
+			t.Fatalf("three positional args should fail, got: %s", out)
+		}
+	})
+}
+
+func TestE2E_MoveCurrentWorktree(t *testing.T) {
+	t.Parallel()
+	binPath := buildBinary(t)
+
+	t.Run("outputs_new_path_with_shell_integration", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "renaming-me")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+		wtPath := worktreePath(out)
+
+		cmd := exec.Command(binPath, "-m", "renamed-out")
+		cmd.Dir = wtPath
+		cmd.Env = append(os.Environ(), "GIT_WT_SHELL_INTEGRATION=1")
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git-wt -m failed: %v\nstderr: %s", err, stderrBuf.String())
+		}
+		stdout := strings.TrimSpace(stdoutBuf.String())
+		if stdout == "" {
+			t.Fatal("expected stdout but got none")
+		}
+
+		expectedNew := filepath.Join(filepath.Dir(wtPath), "renamed-out")
+		assertLastLine(t, stdout, expectedNew)
+
+		if _, err := os.Stat(expectedNew); err != nil {
+			t.Errorf("renamed worktree should exist at %s: %v", expectedNew, err)
+		}
+	})
+
+	t.Run("no_stdout_without_shell_integration", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "quiet-rename")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+		wtPath := worktreePath(out)
+
+		stdout, stderr, err := runGitWtStdout(t, binPath, wtPath, "-m", "quiet-renamed")
+		if err != nil {
+			t.Fatalf("git-wt -m failed: %v\nstderr: %s", err, stderr)
+		}
+		if strings.TrimSpace(stdout) != "" {
+			t.Errorf("stdout should be empty without GIT_WT_SHELL_INTEGRATION, got: %s", stdout)
+		}
+		if !strings.Contains(stderr, "Renamed") && !strings.Contains(stderr, "Moved") {
+			t.Errorf("stderr should mention rename/move, got: %s", stderr)
+		}
+	})
+
+	t.Run("shell_integration_cd_to_new_path", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			shell      string
+			scriptFunc func(repoRoot, wtPath, pathDir, newName string) string
+		}{
+			{
+				name:  "bash",
+				shell: "bash",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init bash)"
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "zsh",
+				shell: "zsh",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init zsh)"
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "fish",
+				shell: "fish",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -x PATH %s $PATH
+git wt --init fish | source
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if _, err := exec.LookPath(tt.shell); err != nil {
+					t.Skipf("%s not available", tt.shell)
+				}
+
+				repo := testutil.NewTestRepo(t)
+				repo.CreateFile("README.md", "# Test")
+				repo.Commit("initial commit")
+
+				oldName := fmt.Sprintf("shell-%s-old", tt.shell)
+				newName := fmt.Sprintf("shell-%s-new", tt.shell)
+
+				out, err := runGitWt(t, binPath, repo.Root, oldName)
+				if err != nil {
+					t.Fatalf("failed to create worktree: %v", err)
+				}
+				oldPath := worktreePath(out)
+				expectedNew := filepath.Join(filepath.Dir(oldPath), newName)
+
+				script := tt.scriptFunc(repo.Root, oldPath, filepath.Dir(binPath), newName)
+				cmd := exec.Command(tt.shell, "-c", script) //#nosec G204
+				cmdOut, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("%s shell integration failed: %v\noutput: %s", tt.shell, err, cmdOut)
+				}
+
+				output := strings.TrimSpace(string(cmdOut))
+				lines := strings.Split(output, "\n")
+				pwd := lines[len(lines)-1]
+
+				// Resolve symlinks for comparison (macOS /private/var vs /var).
+				resolvedExpected, errExp := filepath.EvalSymlinks(expectedNew)
+				resolvedPwd, errPwd := filepath.EvalSymlinks(pwd)
+				if pwd != expectedNew && (errExp != nil || errPwd != nil || resolvedExpected != resolvedPwd) {
+					t.Errorf("pwd should be %q after rename, got %q\nfull output: %s", expectedNew, pwd, output)
+				}
+			})
+		}
+	})
+}

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -105,7 +105,7 @@ func TestE2E_MoveWorktree(t *testing.T) {
 		}
 	})
 
-	t.Run("target_dir_exists_blocks_safe", func(t *testing.T) {
+	t.Run("target_dir_exists_blocks_even_force", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)
 		repo.CreateFile("README.md", "# Test")
@@ -118,12 +118,24 @@ func TestE2E_MoveWorktree(t *testing.T) {
 			t.Fatalf("failed to create worktree dst: %v", err)
 		}
 
+		// Safe rename refuses target dir collisions.
 		out, err := runGitWt(t, binPath, repo.Root, "-m", "src", "dst")
 		if err == nil {
 			t.Fatalf("rename should fail when target dir exists, got: %s", out)
 		}
 		if !strings.Contains(out, "already exists") {
 			t.Errorf("error should mention 'already exists', got: %s", out)
+		}
+
+		// -M does NOT change target-dir behavior because `git worktree move
+		// --force` does not overwrite an existing destination directory; force
+		// only relaxes dirty/locked-worktree checks.
+		out, err = runGitWt(t, binPath, repo.Root, "-M", "src", "dst")
+		if err == nil {
+			t.Fatalf("-M rename should also fail when target dir exists, got: %s", out)
+		}
+		if !strings.Contains(out, "already exists") {
+			t.Errorf("error should mention 'already exists' under -M too, got: %s", out)
 		}
 	})
 
@@ -293,6 +305,33 @@ func TestE2E_MoveWorktree(t *testing.T) {
 		out, err := runGitWt(t, binPath, repo.Root, "-m", "-b", "x", "with-b", "y")
 		if err == nil {
 			t.Fatalf("-m with -b should fail, got: %s", out)
+		}
+	})
+
+	t.Run("rejects_invalid_branch_name_before_move", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		out, err := runGitWt(t, binPath, repo.Root, "valid-src")
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+		oldPath := worktreePath(out)
+
+		// "foo..bar" is rejected by git check-ref-format.
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "valid-src", "foo..bar")
+		if err == nil {
+			t.Fatalf("rename should reject invalid branch name, got: %s", out)
+		}
+		if !strings.Contains(out, "invalid branch name") {
+			t.Errorf("error should mention 'invalid branch name', got: %s", out)
+		}
+
+		// Worktree directory must NOT have been moved.
+		if _, err := os.Stat(oldPath); err != nil {
+			t.Errorf("worktree directory should be untouched after rejected rename, got: %v", err)
 		}
 	})
 

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -292,6 +292,32 @@ func TestE2E_MoveWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("two_arg_rejects_main_working_tree", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Two-arg form pointing at the main working tree via "." must be
+		// rejected explicitly, not punted to `git worktree move`.
+		out, err := runGitWt(t, binPath, repo.Root, "-m", ".", "renamed-main")
+		if err == nil {
+			t.Fatalf("renaming the main working tree should fail, got: %s", out)
+		}
+		if !strings.Contains(out, "main working tree") {
+			t.Errorf("error should mention 'main working tree', got: %s", out)
+		}
+
+		// And via its branch name (main).
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "--allow-delete-default", "main", "renamed-main")
+		if err == nil {
+			t.Fatalf("renaming the main working tree by branch should fail, got: %s", out)
+		}
+		if !strings.Contains(out, "main working tree") {
+			t.Errorf("error should mention 'main working tree', got: %s", out)
+		}
+	})
+
 	t.Run("rejects_b_flag", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -308,6 +308,93 @@ func TestE2E_MoveWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("respects_basedir_flag_override", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		altBase := filepath.Join(repo.ParentDir(), "alt-base")
+
+		// Create the worktree under the overridden basedir.
+		out, err := runGitWt(t, binPath, repo.Root, "--basedir", altBase, "alt-src")
+		if err != nil {
+			t.Fatalf("failed to create worktree under alt basedir: %v\noutput: %s", err, out)
+		}
+		oldPath := worktreePath(out)
+		expectedOld := filepath.Join(altBase, "alt-src")
+		if oldPath != expectedOld {
+			// Tolerate symlink resolution differences on macOS.
+			resolvedOld, errOld := filepath.EvalSymlinks(oldPath)
+			resolvedExpected, errExp := filepath.EvalSymlinks(expectedOld)
+			if errOld != nil || errExp != nil || resolvedOld != resolvedExpected {
+				t.Fatalf("worktree should live under %q, got %q", expectedOld, oldPath)
+			}
+		}
+
+		// Rename it using the same basedir override. Without the override
+		// being honored by -m, the rename would compute paths against the
+		// default .wt basedir and fail to find the worktree or clean up the
+		// wrong tree.
+		out, err = runGitWt(t, binPath, repo.Root, "--basedir", altBase, "-m", "alt-src", "alt-dst")
+		if err != nil {
+			t.Fatalf("rename with --basedir override failed: %v\noutput: %s", err, out)
+		}
+
+		newPath := filepath.Join(altBase, "alt-dst")
+		if _, err := os.Stat(newPath); err != nil {
+			t.Errorf("renamed worktree should exist at %q: %v", newPath, err)
+		}
+	})
+
+	t.Run("branch_only_rename_when_dir_already_matches", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		// Create a worktree where dir name (mydir) differs from branch name
+		// (some-branch) via the -b flag.
+		out, err := runGitWt(t, binPath, repo.Root, "-b", "some-branch", "mydir")
+		if err != nil {
+			t.Fatalf("failed to create worktree with -b: %v\noutput: %s", err, out)
+		}
+		wtPath := worktreePath(out)
+
+		// Renaming to "mydir" should succeed: the directory already matches,
+		// only the branch needs renaming. Before the fix this would fail with
+		// "target worktree directory ... already exists".
+		out, err = runGitWt(t, binPath, repo.Root, "-m", "some-branch", "mydir")
+		if err != nil {
+			t.Fatalf("branch-only rename should succeed when dir already matches: %v\noutput: %s", err, out)
+		}
+
+		// Directory unchanged.
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Errorf("worktree directory should still exist at %q: %v", wtPath, err)
+		}
+
+		// Branch renamed.
+		cmd := exec.Command("git", "branch", "--list", "mydir")
+		cmd.Dir = repo.Root
+		branchOut, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list failed: %v", err)
+		}
+		if !strings.Contains(string(branchOut), "mydir") {
+			t.Errorf("mydir branch should exist after branch-only rename, got: %s", branchOut)
+		}
+		cmd = exec.Command("git", "branch", "--list", "some-branch")
+		cmd.Dir = repo.Root
+		branchOut, err = cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list failed: %v", err)
+		}
+		if strings.Contains(string(branchOut), "some-branch") {
+			t.Errorf("some-branch should have been renamed away, still found: %s", branchOut)
+		}
+	})
+
 	t.Run("rejects_invalid_branch_name_before_move", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -552,6 +552,195 @@ func TestE2E_MoveCurrentWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("nocd_create_still_cds_on_rename", func(t *testing.T) {
+		// Reproduces the maintainer's spec from issue #184: when
+		// `wt.nocd=create` is set, rename targets an existing worktree at a
+		// new location (not a fresh creation), so the shell wrapper must
+		// still cd to the new path.
+		tests := []struct {
+			name       string
+			shell      string
+			scriptFunc func(repoRoot, wtPath, pathDir, newName string) string
+		}{
+			{
+				name:  "bash",
+				shell: "bash",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init bash)"
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "zsh",
+				shell: "zsh",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init zsh)"
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "fish",
+				shell: "fish",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -x PATH %s $PATH
+git wt --init fish | source
+cd %q
+git wt -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if _, err := exec.LookPath(tt.shell); err != nil {
+					t.Skipf("%s not available", tt.shell)
+				}
+
+				repo := testutil.NewTestRepo(t)
+				repo.CreateFile("README.md", "# Test")
+				repo.Commit("initial commit")
+				repo.Git("config", "wt.nocd", "create")
+
+				oldName := fmt.Sprintf("nocdcr-%s-old", tt.shell)
+				newName := fmt.Sprintf("nocdcr-%s-new", tt.shell)
+
+				out, err := runGitWt(t, binPath, repo.Root, oldName)
+				if err != nil {
+					t.Fatalf("failed to create worktree: %v", err)
+				}
+				oldPath := worktreePath(out)
+				expectedNew := filepath.Join(filepath.Dir(oldPath), newName)
+
+				script := tt.scriptFunc(repo.Root, oldPath, filepath.Dir(binPath), newName)
+				cmd := exec.Command(tt.shell, "-c", script) //#nosec G204
+				cmdOut, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("%s shell integration failed: %v\noutput: %s", tt.shell, err, cmdOut)
+				}
+
+				output := strings.TrimSpace(string(cmdOut))
+				lines := strings.Split(output, "\n")
+				pwd := lines[len(lines)-1]
+
+				resolvedExpected, errExp := filepath.EvalSymlinks(expectedNew)
+				resolvedPwd, errPwd := filepath.EvalSymlinks(pwd)
+				if pwd != expectedNew && (errExp != nil || errPwd != nil || resolvedExpected != resolvedPwd) {
+					t.Errorf("wt.nocd=create should still cd on rename, expected pwd=%q, got %q\nfull output: %s", expectedNew, pwd, output)
+				}
+			})
+		}
+	})
+
+	t.Run("nocd_flag_suppresses_cd_on_rename", func(t *testing.T) {
+		// The maintainer's spec also says `--nocd` always suppresses the
+		// cd, even when combined with `-m`. Verify the wrapper's precedence:
+		// --nocd (nocd_flag) is checked before rename_flag.
+		tests := []struct {
+			name       string
+			shell      string
+			scriptFunc func(repoRoot, wtPath, pathDir, newName string) string
+		}{
+			{
+				name:  "bash",
+				shell: "bash",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init bash)"
+cd %q
+git wt --nocd -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "zsh",
+				shell: "zsh",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -e
+export PATH="%s:$PATH"
+eval "$(git wt --init zsh)"
+cd %q
+git wt --nocd -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+			{
+				name:  "fish",
+				shell: "fish",
+				scriptFunc: func(repoRoot, wtPath, pathDir, newName string) string {
+					return fmt.Sprintf(`
+set -x PATH %s $PATH
+git wt --init fish | source
+cd %q
+git wt --nocd -m %s
+pwd
+`, pathDir, wtPath, newName)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if _, err := exec.LookPath(tt.shell); err != nil {
+					t.Skipf("%s not available", tt.shell)
+				}
+
+				repo := testutil.NewTestRepo(t)
+				repo.CreateFile("README.md", "# Test")
+				repo.Commit("initial commit")
+
+				oldName := fmt.Sprintf("nocdflag-%s-old", tt.shell)
+				newName := fmt.Sprintf("nocdflag-%s-new", tt.shell)
+
+				out, err := runGitWt(t, binPath, repo.Root, oldName)
+				if err != nil {
+					t.Fatalf("failed to create worktree: %v", err)
+				}
+				oldPath := worktreePath(out)
+				expectedNew := filepath.Join(filepath.Dir(oldPath), newName)
+
+				script := tt.scriptFunc(repo.Root, oldPath, filepath.Dir(binPath), newName)
+				cmd := exec.Command(tt.shell, "-c", script) //#nosec G204
+				cmdOut, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("%s shell integration failed: %v\noutput: %s", tt.shell, err, cmdOut)
+				}
+
+				output := strings.TrimSpace(string(cmdOut))
+				lines := strings.Split(output, "\n")
+				pwd := lines[len(lines)-1]
+
+				// pwd must NOT have changed to the new path.
+				resolvedExpected, errExp := filepath.EvalSymlinks(expectedNew)
+				resolvedPwd, errPwd := filepath.EvalSymlinks(pwd)
+				if pwd == expectedNew || (errExp == nil && errPwd == nil && resolvedExpected == resolvedPwd) {
+					t.Errorf("--nocd should suppress cd on rename, but pwd changed to %q\nfull output: %s", pwd, output)
+				}
+			})
+		}
+	})
+
 	t.Run("shell_integration_cd_to_new_path", func(t *testing.T) {
 		t.Parallel()
 		tests := []struct {

--- a/e2e/move_test.go
+++ b/e2e/move_test.go
@@ -308,6 +308,35 @@ func TestE2E_MoveWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("respects_basedir_flag_override_with_dir_query", func(t *testing.T) {
+		t.Parallel()
+		repo := testutil.NewTestRepo(t)
+		repo.CreateFile("README.md", "# Test")
+		repo.Commit("initial commit")
+
+		altBase := filepath.Join(repo.ParentDir(), "alt-base-dirq")
+
+		// Create a worktree with -b so the directory name (dirX) differs
+		// from the branch name (branchX), under an overridden basedir.
+		if _, err := runGitWt(t, binPath, repo.Root, "--basedir", altBase, "-b", "branchX", "dirX"); err != nil {
+			t.Fatalf("failed to create worktree with -b under alt basedir: %v", err)
+		}
+
+		// Rename by *directory* name (not branch name) while keeping the
+		// basedir override. Without the override-aware fallback, this query
+		// fails because FindWorktreeByBranchOrDir's basedir-relative match
+		// path uses unoverridden config.
+		out, err := runGitWt(t, binPath, repo.Root, "--basedir", altBase, "-m", "dirX", "dirY")
+		if err != nil {
+			t.Fatalf("rename by dir name with --basedir override failed: %v\noutput: %s", err, out)
+		}
+
+		newPath := filepath.Join(altBase, "dirY")
+		if _, err := os.Stat(newPath); err != nil {
+			t.Errorf("renamed worktree should exist at %q: %v", newPath, err)
+		}
+	})
+
 	t.Run("respects_basedir_flag_override", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -116,7 +116,9 @@ func RenameBranch(ctx context.Context, oldName, newName string, force bool, dir 
 	if dir != "" {
 		args = append(args, "-C", dir)
 	}
-	args = append(args, "branch", flag, oldName, newName)
+	// Pass branch names after `--` so that names beginning with `-`
+	// (e.g. `-q`) are not parsed as options by `git branch`.
+	args = append(args, "branch", flag, "--", oldName, newName)
 	cmd, err := gitCommand(ctx, args...)
 	if err != nil {
 		return err

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -82,6 +82,21 @@ func DeleteBranchInDir(ctx context.Context, name string, force bool, dir string)
 	return cmd.Run()
 }
 
+// CheckBranchNameFormat validates that name is a syntactically valid Git
+// branch name (e.g., rejects "foo..bar", names ending with ".lock", etc.),
+// using `git check-ref-format refs/heads/<name>`. It does not check whether
+// the branch already exists.
+func CheckBranchNameFormat(ctx context.Context, name string) error {
+	cmd, err := gitCommand(ctx, "check-ref-format", "refs/heads/"+name)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("invalid branch name %q: %w", name, err)
+	}
+	return nil
+}
+
 // RenameBranch renames a branch from oldName to newName.
 // If force is true, it uses -M (force rename, allows overwriting an existing
 // target branch), otherwise -m (safe rename). When dir is non-empty the

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -91,6 +91,10 @@ func CheckBranchNameFormat(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+	// Forward stderr so any explanation git emits about the malformed ref
+	// surfaces to the user, matching the style of the other git helpers in
+	// this package.
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("invalid branch name %q: %w", name, err)
 	}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -82,6 +82,31 @@ func DeleteBranchInDir(ctx context.Context, name string, force bool, dir string)
 	return cmd.Run()
 }
 
+// RenameBranch renames a branch from oldName to newName.
+// If force is true, it uses -M (force rename, allows overwriting an existing
+// target branch), otherwise -m (safe rename). When dir is non-empty the
+// command is run with 'git -C <dir>', which is required when the calling
+// process's working directory has just been removed (e.g., after moving the
+// current worktree).
+func RenameBranch(ctx context.Context, oldName, newName string, force bool, dir string) error {
+	flag := "-m"
+	if force {
+		flag = "-M"
+	}
+	var args []string
+	if dir != "" {
+		args = append(args, "-C", dir)
+	}
+	args = append(args, "branch", flag, oldName, newName)
+	cmd, err := gitCommand(ctx, args...)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // IsBranchMerged checks if a branch is merged into the current branch.
 func IsBranchMerged(ctx context.Context, name string) (bool, error) {
 	cmd, err := gitCommand(ctx, "branch", "--merged")

--- a/internal/git/repo_context.go
+++ b/internal/git/repo_context.go
@@ -92,6 +92,12 @@ func DetectRepoContext(ctx context.Context) (RepoContext, error) {
 	return rc, nil
 }
 
+// IsLinkedWorktree reports whether the current directory is a linked worktree
+// (i.e., not the main working tree and not a bare-repo root).
+func (rc *RepoContext) IsLinkedWorktree() bool {
+	return rc.worktree
+}
+
 // IsBareRepository reports whether the main repository is bare.
 // It is a convenience wrapper around DetectRepoContext.
 func IsBareRepository(ctx context.Context) (bool, error) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -553,7 +553,11 @@ func isStrictDescendant(path, root string) bool {
 	if rel == "." || rel == "" {
 		return false
 	}
-	if strings.HasPrefix(rel, "..") {
+	// Reject only genuine parent traversals: the rel must be exactly ".."
+	// or start with "../" (i.e. ".." followed by the path separator).
+	// A bare strings.HasPrefix(rel, "..") would also reject legitimate
+	// child names that happen to start with two dots (e.g. "..cache").
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return false
 	}
 	return true
@@ -568,6 +572,14 @@ func isStrictDescendant(path, root string) bool {
 func onlyUntouchedDecorationFiles(dir string, entries []os.DirEntry) (bool, error) {
 	for _, e := range entries {
 		if e.IsDir() {
+			return false, nil
+		}
+		// Symlinks report IsDir()==false even when they point at a directory.
+		// Conservatively refuse to remove a directory containing any symlink:
+		// a symlink named .gitignore/README.md whose target happens to match
+		// the expected content would otherwise be considered removable, and
+		// os.RemoveAll would follow the symlink semantics unpredictably.
+		if e.Type()&os.ModeSymlink != 0 {
 			return false, nil
 		}
 		var want string

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -448,3 +448,77 @@ func RemoveWorktree(ctx context.Context, path string, force bool) error {
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
+
+// MoveWorktree moves a worktree directory from oldPath to newPath using
+// 'git worktree move'. The parent directory of newPath is created if needed.
+// If force is true, '--force' is passed to allow moving worktrees with
+// uncommitted or untracked changes.
+func MoveWorktree(ctx context.Context, oldPath, newPath string, force bool) error {
+	parentDir := filepath.Dir(newPath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return fmt.Errorf("failed to create parent directory: %w", err)
+	}
+	if err := initBaseDir(parentDir); err != nil {
+		return err
+	}
+
+	args := []string{"worktree", "move"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, oldPath, newPath)
+
+	cmd, err := gitCommand(ctx, args...)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// RemoveEmptyParents walks up from startDir removing empty directories until
+// it reaches stopDir (exclusive) or hits a non-empty directory. stopDir is
+// never removed. Both paths should be absolute and clean.
+//
+// Directories that contain only the basedir decoration files written by
+// initBaseDir (.gitignore, README.md) are treated as empty for cleanup
+// purposes, because slash-style branch names (e.g. "feat/foo") cause those
+// files to be planted in every intermediate directory under basedir.
+func RemoveEmptyParents(startDir, stopDir string) error {
+	stopDir = filepath.Clean(stopDir)
+	cur := filepath.Clean(startDir)
+	for cur != stopDir && cur != "/" && cur != "." {
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				cur = filepath.Dir(cur)
+				continue
+			}
+			return err
+		}
+		if !onlyDecorationFiles(entries) {
+			return nil
+		}
+		if err := os.RemoveAll(cur); err != nil {
+			return err
+		}
+		cur = filepath.Dir(cur)
+	}
+	return nil
+}
+
+func onlyDecorationFiles(entries []os.DirEntry) bool {
+	for _, e := range entries {
+		if e.IsDir() {
+			return false
+		}
+		switch e.Name() {
+		case ".gitignore", "README.md":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -378,19 +378,15 @@ func AddWorktreeWithNewBranch(ctx context.Context, path, branch, startPoint stri
 	return copyAfterAdd(ctx, ac, path, copyOpts)
 }
 
-// initBaseDir initializes the basedir with .gitignore and README.md files.
-// It creates these files only if they don't already exist.
-func initBaseDir(baseDir string) error {
-	gitignorePath := filepath.Join(baseDir, ".gitignore")
-	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
-		if err := os.WriteFile(gitignorePath, []byte("*\n"), 0600); err != nil {
-			return fmt.Errorf("failed to create .gitignore: %w", err)
-		}
-	}
+// baseDirGitignoreContent is the exact content initBaseDir plants into a
+// fresh basedir's .gitignore. It is also used by RemoveEmptyParents to
+// recognize an untouched decoration file when cleaning up.
+const baseDirGitignoreContent = "*\n"
 
-	readmePath := filepath.Join(baseDir, "README.md")
-	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
-		readmeContent := `# Git worktrees added by ` + "`git wt`" + `
+// baseDirReadmeContent is the exact content initBaseDir plants into a fresh
+// basedir's README.md. It is also used by RemoveEmptyParents to recognize an
+// untouched decoration file when cleaning up.
+const baseDirReadmeContent = `# Git worktrees added by ` + "`git wt`" + `
 
 This directory contains Git worktrees created with ` + "`git wt`" + `.
 
@@ -400,7 +396,20 @@ This directory contains Git worktrees created with ` + "`git wt`" + `.
 - Depending on your configuration, this directory may be placed under a Git repository.
   A ` + "`.gitignore`" + ` file ensures everything under it is ignored in that case.
 `
-		if err := os.WriteFile(readmePath, []byte(readmeContent), 0600); err != nil {
+
+// initBaseDir initializes the basedir with .gitignore and README.md files.
+// It creates these files only if they don't already exist.
+func initBaseDir(baseDir string) error {
+	gitignorePath := filepath.Join(baseDir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		if err := os.WriteFile(gitignorePath, []byte(baseDirGitignoreContent), 0600); err != nil {
+			return fmt.Errorf("failed to create .gitignore: %w", err)
+		}
+	}
+
+	readmePath := filepath.Join(baseDir, "README.md")
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		if err := os.WriteFile(readmePath, []byte(baseDirReadmeContent), 0600); err != nil {
 			return fmt.Errorf("failed to create README.md: %w", err)
 		}
 	}
@@ -479,46 +488,99 @@ func MoveWorktree(ctx context.Context, oldPath, newPath string, force bool) erro
 
 // RemoveEmptyParents walks up from startDir removing empty directories until
 // it reaches stopDir (exclusive) or hits a non-empty directory. stopDir is
-// never removed. Both paths should be absolute and clean.
+// never removed.
+//
+// Both paths must be absolute and clean. As a safety guard, startDir must
+// itself be a strict descendant of stopDir; otherwise the walk refuses to
+// remove anything (returning nil) so a misconfigured basedir cannot cause
+// the loop to climb out of basedir and delete unrelated directories.
 //
 // Directories that contain only the basedir decoration files written by
 // initBaseDir (.gitignore, README.md) are treated as empty for cleanup
 // purposes, because slash-style branch names (e.g. "feat/foo") cause those
 // files to be planted in every intermediate directory under basedir.
+// To avoid clobbering user-edited files, the decoration files are only
+// considered removable when their content is bit-identical to what
+// initBaseDir wrote.
 func RemoveEmptyParents(startDir, stopDir string) error {
 	stopDir = filepath.Clean(stopDir)
 	cur := filepath.Clean(startDir)
-	for cur != stopDir && cur != "/" && cur != "." {
+	if !isStrictDescendant(cur, stopDir) {
+		return nil
+	}
+	for cur != stopDir {
 		entries, err := os.ReadDir(cur)
 		if err != nil {
 			if os.IsNotExist(err) {
 				cur = filepath.Dir(cur)
+				if !isStrictDescendant(cur, stopDir) && cur != stopDir {
+					return nil
+				}
 				continue
 			}
 			return err
 		}
-		if !onlyDecorationFiles(entries) {
+		removable, err := onlyUntouchedDecorationFiles(cur, entries)
+		if err != nil {
+			return err
+		}
+		if !removable {
 			return nil
 		}
 		if err := os.RemoveAll(cur); err != nil {
 			return err
 		}
 		cur = filepath.Dir(cur)
+		if !isStrictDescendant(cur, stopDir) && cur != stopDir {
+			return nil
+		}
 	}
 	return nil
 }
 
-func onlyDecorationFiles(entries []os.DirEntry) bool {
-	for _, e := range entries {
-		if e.IsDir() {
-			return false
-		}
-		switch e.Name() {
-		case ".gitignore", "README.md":
-			continue
-		default:
-			return false
-		}
+// isStrictDescendant reports whether path lies strictly below root.
+// Both inputs must already be absolute and filepath.Clean'd.
+func isStrictDescendant(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == "" {
+		return false
+	}
+	if strings.HasPrefix(rel, "..") {
+		return false
 	}
 	return true
+}
+
+// onlyUntouchedDecorationFiles reports whether the entries of dir consist
+// solely of .gitignore and/or README.md files whose content matches what
+// initBaseDir wrote. Empty directories are also considered "removable" by
+// returning true with an empty entries slice. Any subdirectory, any other
+// filename, or a decoration file whose content has been edited makes the
+// directory non-removable.
+func onlyUntouchedDecorationFiles(dir string, entries []os.DirEntry) (bool, error) {
+	for _, e := range entries {
+		if e.IsDir() {
+			return false, nil
+		}
+		var want string
+		switch e.Name() {
+		case ".gitignore":
+			want = baseDirGitignoreContent
+		case "README.md":
+			want = baseDirReadmeContent
+		default:
+			return false, nil
+		}
+		got, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return false, err
+		}
+		if string(got) != want {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -490,9 +490,11 @@ func MoveWorktree(ctx context.Context, oldPath, newPath string, force bool) erro
 // it reaches stopDir (exclusive) or hits a non-empty directory. stopDir is
 // never removed.
 //
-// Both paths must be absolute and clean. As a safety guard, startDir must
-// itself be a strict descendant of stopDir; otherwise the walk refuses to
-// remove anything (returning nil) so a misconfigured basedir cannot cause
+// Both paths must be absolute; the function returns an error otherwise so a
+// caller that hands in a relative path cannot accidentally trigger deletions
+// against its current working directory. As a further safety guard, startDir
+// must itself be a strict descendant of stopDir; otherwise the walk refuses
+// to remove anything (returning nil) so a misconfigured basedir cannot cause
 // the loop to climb out of basedir and delete unrelated directories.
 //
 // Directories that contain only the basedir decoration files written by
@@ -503,6 +505,9 @@ func MoveWorktree(ctx context.Context, oldPath, newPath string, force bool) erro
 // considered removable when their content is bit-identical to what
 // initBaseDir wrote.
 func RemoveEmptyParents(startDir, stopDir string) error {
+	if !filepath.IsAbs(startDir) || !filepath.IsAbs(stopDir) {
+		return fmt.Errorf("absolute paths required: startDir=%q stopDir=%q", startDir, stopDir)
+	}
 	stopDir = filepath.Clean(stopDir)
 	cur := filepath.Clean(startDir)
 	if !isStrictDescendant(cur, stopDir) {


### PR DESCRIPTION
Closes #184

## Summary

Renaming a git-wt worktree previously required several manual steps: `git branch -m`, `git worktree move`, cleaning up empty parent directories (notably when branch names contain `/`), and re-`cd`-ing if you were inside the renamed worktree. This PR adds a single-step rename that completes the existing create / switch / delete vocabulary.

- `git wt -m <new>` renames the current worktree's directory and branch in one go.
- `git wt -m <old> <new>` renames an explicit worktree.
- `git wt -M ...` is the force variant: overwrites an existing target branch (via `git branch -M`) and allows moving worktrees with uncommitted changes (via `git worktree move --force`).

## Design decisions

- **Argument shape**: mirrors `git branch -m` (1-arg form acts on the current branch; 2-arg form takes old/new). Two args are always `<old> <new>`.
- **Mismatched dir/branch (created via `-b`)**: both directory and branch are renamed to `<new>`, treating the worktree as a single named entity.
- **Detached HEAD**: error. There is no branch to rename, and silently renaming just the directory felt like the wrong default.
- **Main working tree**: cannot be renamed. The `-m <new>` form only acts on linked worktrees.
- **Default branch protection**: reuses `--allow-delete-default`. Without the flag, attempting to rename a worktree whose branch is the default fails.
- **Slash-style branches** (e.g. `feat/foo`): empty parent directories under `wt.basedir` are cleaned up after the move. The cleanup also removes the `.gitignore` / `README.md` files that `initBaseDir` plants in every intermediate directory; without that, `.wt/feat/` would never look "empty" after renaming the only child out.
- **Conflicts**: target directory existence and target branch existence are checked up front and produce a clear error pointing at `-M`. With `-M`, `git worktree move --force` and `git branch -M` handle the rest.
- **Hooks**: `wt.hook` and `wt.deletehook` do **not** fire on rename. Rename is neither a creation nor a deletion.
- **Shell integration**: when the current worktree is renamed, the new path is printed on the last line so the shell wrapper `cd`s there. The bash/zsh/fish/powershell wrappers now detect `-m`/`-M` in argv so `wt.nocd=create` still allows the `cd` (rename targets an existing worktree at a new location, not a creation), matching the semantics agreed on in the issue thread.

## Test plan

- [x] `TestE2E_MoveWorktree`: two-arg rename, one-arg rename of current, refuses outside a linked worktree, target directory/branch conflicts (safe and force), slash-style branch with parent cleanup, default branch protection (blocked, then allowed with `--allow-delete-default`), detached HEAD rejected, `-m` rejects `-b`, rejects 3+ args.
- [x] `TestE2E_MoveCurrentWorktree`: prints new path on last line under `GIT_WT_SHELL_INTEGRATION=1`, stays silent otherwise, and bash/zsh/fish wrappers actually `cd` to the new path.
- [x] `make test` and `make lint` clean.