### PR TITLE
Don't consider remote branches when start-point is given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1039,16 +1039,25 @@ func handleWorktree(ctx context.Context, cmd *cobra.Command, wtName, branchName,
 	}
 
 	// Check if branch exists
-	exists, err := git.BranchExists(ctx, branchName)
-	if err != nil {
-		return fmt.Errorf("failed to check branch: %w", err)
+	var exists bool
+	if startPoint != "" {
+		exists, err = git.LocalBranchExists(ctx, branchName)
+		if err != nil {
+			return fmt.Errorf("failed to check branch: %w", err)
+		}
+	} else {
+		exists, err = git.BranchExists(ctx, branchName)
+		if err != nil {
+			return fmt.Errorf("failed to check branch: %w", err)
+		}
 	}
 
 	if exists {
 		if startPoint != "" {
 			return fmt.Errorf("branch %q already exists (start-point %q is not allowed for existing branches)", branchName, startPoint)
 		}
-		// Branch exists, create worktree with existing branch
+		// Create worktree with existing local branch,
+		// or create new branch using DWIM when matching remote branch exists.
 		if err := git.AddWorktree(ctx, wtPath, branchName, copyOpts); err != nil {
 			return fmt.Errorf("failed to create worktree: %w", err)
 		}

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -388,6 +388,69 @@ func TestE2E_CreateWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("with_remote_start_point_for_ambiguous_remote_branch", func(t *testing.T) {
+		t.Parallel()
+		// Create a "remote" repo
+		remoteRepo := testutil.NewTestRepo(t)
+		remoteRepo.CreateFile("README.md", "# Remote")
+		remoteRepo.Commit("remote initial commit")
+		remoteRepo.CreateFile("remote-file.txt", "remote content")
+		remoteRepo.Commit("remote second commit")
+
+		remoteRepo.Git("branch", "old-base", "HEAD~1")
+
+		// Clone the remote repo
+		cloneDir := t.TempDir()
+		clonePath := filepath.Join(cloneDir, "clone")
+		cmd := exec.Command("git", "clone", remoteRepo.Root, clonePath)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git clone failed: %v\noutput: %s", err, out)
+		}
+
+		cmd = exec.Command("git", "remote", "add", "another", remoteRepo.Root)
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git remote add failed: %v\noutput: %s", err, out)
+		}
+
+		cmd = exec.Command("git", "fetch", "another")
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git fetch another failed: %v\noutput: %s", err, out)
+		}
+
+		// assert the branch name is ambiguous
+		cmd = exec.Command("git", "for-each-ref", "refs/remotes/*/old-base")
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git for-each-ref failed: %v\noutput: %s", err, out)
+		} else if strings.Count(string(out), "/old-base\n") < 2 {
+			t.Fatalf("there should be multiple matches\noutput: %s", out)
+		}
+		// ambiguous remote branch cannot be checked out
+		cmd = exec.Command("git", "checkout", "old-base")
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err == nil {
+			t.Fatalf("git checkout succeeded unexpectedly\noutput: %s", out)
+		}
+
+		stdout, stderr, err := runGitWtStdout(t, binPath, clonePath, "old-base", "origin/old-base")
+		if err != nil {
+			t.Fatalf("git-wt with remote start-point failed: %v\nstderr: %s", err, stderr)
+		}
+
+		wtPath := strings.TrimSpace(stdout)
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree was not created at %s", wtPath)
+		}
+
+		// Verify the worktree is based on the first commit (should NOT have remote-file.txt)
+		remoteFilePath := filepath.Join(wtPath, "remote-file.txt")
+		if _, err := os.Stat(remoteFilePath); !os.IsNotExist(err) {
+			t.Error("worktree should NOT have remote-file.txt (should be based on origin/old-base)")
+		}
+	})
+
 	t.Run("existing_branch", func(t *testing.T) {
 		t.Parallel()
 		repo := testutil.NewTestRepo(t)


### PR DESCRIPTION
When a start-point is specified, the branch name is expected to be created from that start-point. Do not consider a matching remote-tracking branch as an existing branch.

This allows creating a tracking branch and worktree from an ambiguous remote by specifying the start-point explicitly.

# Problem to be solved

Suppose we have two remotes and remote tracking branches origin/foo and another/foo, and there is no local branch foo.
'git wt foo' cannot perform DWIM to create branch because there are multiple matching remotes.

```
% git wt foo
fatal: invalid reference: foo
Error: failed to create worktree: exit status 128
```

Then we try 'git wt foo origin/foo' to solve this issue, we get another error

```
% git wt foo origin/foo
Error: branch "foo" already exists (start-point "origin/foo" is not allowed for existing branches)
```
The error message says there is a branch "foo", but the branch doesn't exist locally.

This is because it checks remote branches and uses conditional logic to enable DWIM behavior for the 'git wt foo' command.