### PR TITLE
docs: clarify delete semantics and `wt.symlink` prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Invoke-Expression (git wt --init powershell | Out-String)
 > [!IMPORTANT]
 > The shell integration creates a `git()` wrapper function to enable automatic directory switching with `git wt <branch>`. This wrapper intercepts only `git wt <branch>` commands and passes all other git commands through unchanged. If you have other tools or customizations that also wrap the `git` command, there may be conflicts.
 
-The `cd` is performed by that wrapper function, so it only exists in a shell that sourced the script above. The binary itself always prints the resulting worktree path as the **last line of stdout**, which is what the wrapper reads. Git's own progress output goes to stderr and [hook](#wthook----hook) output is printed before the path, so scripts, editors, and other tools can rely on the last line:
+The `cd` is performed by that wrapper function, so it only exists in a shell that sourced the script above. The binary itself always prints the resulting worktree path as the **last line of stdout**, which is what the wrapper reads. Git's own progress output and [hook](#wthook----hook) output both go to stderr, so scripts, editors, and other tools can rely on the last line:
 
 ``` console
 $ WT=$(git wt --nocd feature-branch | tail -1)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The target can be specified as:
 - **path**: a filesystem path (absolute or relative to the current working directory) to an existing worktree —  _eg._ `git wt ../sibling`, `git wt /absolute/path`
 
 > [!NOTE]
-> git-wt has no subcommands. Every non-flag argument is a target name, so `git wt list` creates a worktree named `list` instead of listing anything. Run `git wt` with no arguments to list worktrees.
+> git-wt has no subcommands. The first non-flag argument is always a target name, never a command, so `git wt list` creates a worktree named `list` instead of listing anything. Run `git wt` with no arguments to list worktrees.
 
 When deleting, the same target types apply: `git wt -d feature-branch`, `git wt -d .`, `git wt -d ../sibling`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ The target can be specified as:
 
 When deleting, the same target types apply: `git wt -d feature-branch`, `git wt -d .`, `git wt -d ../sibling`
 
+`-d` is the safe form and stops short when something would be lost:
+
+- If the worktree has modified or untracked files, nothing is deleted. A directory shared through [`wt.symlink`](#wtsymlink----symlink) counts as untracked.
+- If the branch is not fully merged, the worktree is removed but the branch is kept. git-wt reports this and still exits `0`, so read the message rather than only the exit code.
+
+`-D` skips both checks and removes the worktree together with its branch.
+
 Use `-m` (`-M` to force) to rename a worktree's directory and branch in a single operation. With one argument, the current worktree is renamed; with two, an explicit worktree is renamed:
 
 ``` console

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When deleting, the same target types apply: `git wt -d feature-branch`, `git wt 
 
 `-d` is the safe form and stops short when something would be lost:
 
-- If the worktree has modified or untracked files, nothing is deleted. A directory shared through [`wt.symlink`](#wtsymlink----symlink) counts as untracked.
+- If the worktree has modified or untracked files, nothing is deleted. A directory shared through [`wt.symlink`](#wtsymlink----symlink) counts as untracked unless the ignore pattern matches the link itself.
 - If the branch is not fully merged, the worktree is removed but the branch is kept. git-wt reports this and still exits `0`, so read the message rather than only the exit code.
 
 `-D` skips both checks and removes the worktree together with its branch.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The target can be specified as:
 - **worktree**: a directory name relative to [`wt.basedir`](#wtbasedir----basedir) (default `.wt`) — _eg._ `git wt some-worktree-folder-name`
 - **path**: a filesystem path (absolute or relative to the current working directory) to an existing worktree —  _eg._ `git wt ../sibling`, `git wt /absolute/path`
 
+> [!NOTE]
+> git-wt has no subcommands. Every non-flag argument is a target name, so `git wt list` creates a worktree named `list` instead of listing anything. Run `git wt` with no arguments to list worktrees.
+
 When deleting, the same target types apply: `git wt -d feature-branch`, `git wt -d .`, `git wt -d ../sibling`
 
 `-d` is the safe form and stops short when something would be lost:
@@ -105,6 +108,13 @@ Invoke-Expression (git wt --init powershell | Out-String)
 
 > [!IMPORTANT]
 > The shell integration creates a `git()` wrapper function to enable automatic directory switching with `git wt <branch>`. This wrapper intercepts only `git wt <branch>` commands and passes all other git commands through unchanged. If you have other tools or customizations that also wrap the `git` command, there may be conflicts.
+
+The `cd` is performed by that wrapper function, so it only exists in a shell that sourced the script above. The binary itself always prints the resulting worktree path as the **last line of stdout**, which is what the wrapper reads. Git's own progress output goes to stderr and [hook](#wthook----hook) output is printed before the path, so scripts, editors, and other tools can rely on the last line:
+
+``` console
+$ WT=$(git wt --nocd feature-branch | tail -1)
+$ git -C "$WT" status
+```
 
 If you want only completion without the `git()` wrapper (no automatic directory switching), use the `--nocd` option:
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ $ git wt --copy "*.code-workspace" --copy ".vscode/" feature-branch
 
 This is useful when you want to copy specific IDE files (like VS Code workspace files) without enabling `wt.copyignored` for all gitignored files.
 
+Patterns are matched against gitignored and untracked files.
+
 > [!NOTE]
 > The worktree base directory (`wt.basedir`) is always excluded from file copying, regardless of copy options. This prevents circular copying when basedir is inside the repository (e.g., `.worktrees/`).
 
@@ -212,6 +214,25 @@ Supported patterns (same as `.gitignore`):
 
 > [!NOTE]
 > If the same file matches both `wt.copy` and `wt.nocopy`, `wt.nocopy` takes precedence.
+
+#### `wt.symlink` / `--symlink`
+
+Symlink matching top-level directories to the source instead of copying them. Uses `.gitignore` syntax.
+
+Because the directory is shared rather than duplicated, worktree creation stays fast no matter how large it is. The flip side is that every worktree sees the same contents, so an install in one worktree changes all of them.
+
+``` console
+$ git config --add wt.copy "node_modules/"
+$ git config --add wt.symlink "node_modules/"
+# or override for a single invocation (multiple patterns supported)
+$ git wt --copy "node_modules/" --symlink "node_modules/" feature-branch
+```
+
+> [!IMPORTANT]
+> `wt.symlink` only redirects directories that are already going to be copied, so on its own it does nothing. Pair it with `wt.copy` (as above), or with `wt.copyignored` / `wt.copyuntracked` if the directory is already covered by those.
+
+> [!NOTE]
+> A symlink is not a directory, so a trailing-slash `.gitignore` pattern such as `node_modules/` does not match the link and git reports it as untracked. That also makes `git wt -d` refuse to remove the worktree. Drop the trailing slash in `.gitignore`, or add the bare name to `.git/info/exclude`.
 
 #### `wt.hook` / `--hook`
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,9 @@ Examples:
   git wt -m [<old>] <new>                        Rename worktree directory and branch (safe)
   git wt -M [<old>] <new>                        Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 
+Note: git-wt has no subcommands. Every non-flag argument is a branch/worktree name, so
+      'git wt list' creates a worktree named "list". Run 'git wt' with no arguments to list.
+
 Deleting:
   -d is the safe form and stops short when something would be lost.
   - If the worktree has modified or untracked files, nothing is deleted.
@@ -101,6 +104,14 @@ Shell Integration:
 
   # powershell ($PROFILE)
   Invoke-Expression (git-wt --init powershell | Out-String)
+
+  The 'cd' is performed by a shell function, so it only exists in a shell that sourced
+  the script above. The binary itself always prints the resulting worktree path as the
+  last line of stdout, which is what that function reads. Git's own progress output goes
+  to stderr and hook output is printed before the path, so scripts and other tools can
+  rely on the last line:
+
+    WT=$(git wt --nocd <branch> | tail -1)
 
 Configuration:
   Configuration is done via git config. All config options can be overridden

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,8 @@ Note: git-wt has no subcommands. Every non-flag argument is a branch/worktree na
 Deleting:
   -d is the safe form and stops short when something would be lost.
   - If the worktree has modified or untracked files, nothing is deleted.
-    A directory shared through wt.symlink counts as untracked, see wt.symlink below.
+    A directory shared through wt.symlink counts as untracked unless the ignore pattern
+    matches the link itself, see wt.symlink below.
   - If the branch is not fully merged, the worktree is removed but the branch is kept.
     git-wt reports this and still exits 0, so read the message, not just the exit code.
   -D skips both checks and removes the worktree together with its branch.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,14 @@ Examples:
   git wt -m [<old>] <new>                        Rename worktree directory and branch (safe)
   git wt -M [<old>] <new>                        Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 
+Deleting:
+  -d is the safe form and stops short when something would be lost.
+  - If the worktree has modified or untracked files, nothing is deleted.
+    A directory shared through wt.symlink counts as untracked, see wt.symlink below.
+  - If the branch is not fully merged, the worktree is removed but the branch is kept.
+    git-wt reports this and still exits 0, so read the message, not just the exit code.
+  -D skips both checks and removes the worktree together with its branch.
+
 Note: The default branch (e.g., main, master) is protected from accidental deletion or rename.
       Pass --allow-delete-default to override the protection in any of the cases below.
       - With worktree: -d removes the worktree but keeps the branch by default; -m/-M refuses to rename by default.
@@ -205,7 +213,7 @@ func init() {
 	// git-wt uses its own shell integration via --init flag instead.
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
-	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch by name or path (safe delete, only if merged)")
+	rootCmd.Flags().BoolVarP(&deleteFlag, "delete", "d", false, "Delete worktree and branch by name or path (safe delete, refuses a dirty worktree and keeps an unmerged branch)")
 	rootCmd.Flags().BoolVarP(&forceDeleteFlag, "force-delete", "D", false, "Force delete worktree and branch by name or path")
 	rootCmd.Flags().BoolVarP(&moveFlag, "move", "m", false, "Rename worktree directory and branch (safe rename)")
 	rootCmd.Flags().BoolVarP(&forceMoveFlag, "force-move", "M", false, "Force rename worktree directory and branch (allow overwriting existing branch and moving dirty/locked worktrees)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,8 +74,9 @@ Examples:
   git wt -m [<old>] <new>                        Rename worktree directory and branch (safe)
   git wt -M [<old>] <new>                        Force rename (overwrite existing branch, allow moving dirty/locked worktrees)
 
-Note: git-wt has no subcommands. Every non-flag argument is a branch/worktree name, so
-      'git wt list' creates a worktree named "list". Run 'git wt' with no arguments to list.
+Note: git-wt has no subcommands. The first non-flag argument is always a target name, never
+      a command, so 'git wt list' creates a worktree named "list". Run 'git wt' with no
+      arguments to list.
 
 Deleting:
   -d is the safe form and stops short when something would be lost.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,6 +119,8 @@ Configuration:
   wt.copy (--copy)
     Patterns for files to always copy, even if gitignored (gitignore syntax).
     Can be specified multiple times. Useful for copying specific IDE files.
+    Patterns are matched against gitignored and untracked files, so this brings
+    files in without enabling wt.copyignored for everything.
     Example: git config --add wt.copy "*.code-workspace"
              git config --add wt.copy ".vscode/"
 
@@ -134,7 +136,15 @@ Configuration:
     Matching top-level directories are symlinked to the source, sharing the
     same files. This is much faster than copying but changes affect all worktrees.
     Can be specified multiple times.
-    Example: git config --add wt.symlink "node_modules/"
+    Note: this only redirects directories that are already going to be copied. On its
+          own it does nothing, so pair it with wt.copy (or wt.copyignored /
+          wt.copyuntracked) to make the directory a copy target first.
+    Note: a symlink is not a directory, so a trailing-slash gitignore pattern such as
+          "node_modules/" does not match the link and git reports it as untracked.
+          That also makes 'git wt -d' refuse to remove the worktree. Drop the trailing
+          slash, or add the bare name to .git/info/exclude.
+    Example: git config --add wt.copy "node_modules/"
+             git config --add wt.symlink "node_modules/"
 
   wt.hook (--hook)
     Commands to run after creating a new worktree.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,9 +108,8 @@ Shell Integration:
 
   The 'cd' is performed by a shell function, so it only exists in a shell that sourced
   the script above. The binary itself always prints the resulting worktree path as the
-  last line of stdout, which is what that function reads. Git's own progress output goes
-  to stderr and hook output is printed before the path, so scripts and other tools can
-  rely on the last line:
+  last line of stdout, which is what that function reads. Git's own progress output and
+  hook output both go to stderr, so scripts and other tools can rely on the last line:
 
     WT=$(git wt --nocd <branch> | tail -1)
 


### PR DESCRIPTION
## Summary

While exercising git-wt against throwaway repositories, a few behaviours turned out to be either undocumented or documented in a way that leads to the wrong conclusion. This PR fixes the documentation, in `git wt --help` and in `README.md`. No behaviour changes.

The three findings, in the order the commits address them:

- **`wt.symlink` needs a copy source.** It redirects directories that copying was already going to touch, so setting it alone on a gitignored `node_modules` does nothing at all. It was also missing from `README.md` entirely, documented only in `--help`.
- **A symlinked directory shows up as untracked.** A trailing-slash `.gitignore` pattern (`node_modules/`) matches directories, and a symlink is not one, so `git status` reports it and `git wt -d` then refuses to remove the worktree. `.git/info/exclude` keeps the workaround out of a tracked file.
- **`-d` was summarised as "safe delete, only if merged".** That reads as "an unmerged branch is left alone", but the worktree is removed, the branch is kept, and the exit code is still `0`. The other refusal (modified or untracked files in the worktree) was not documented anywhere.
- **The last line of stdout is the path.** The `cd` lives in the shell wrapper, which reads that line. Scripts, editors, and non-interactive callers need the same contract, and nothing said it existed.
- **`git wt list` creates a worktree named `list`.** There are no subcommands, so the bare word is a target name.

## Changes

- `cmd/root.go`: add a `Deleting:` section and a no-subcommands note to the help text, describe the stdout contract under Shell Integration, add the two `wt.symlink` notes and the `wt.copy` match target, and reword the `-d` flag description.
- `README.md`: add a `wt.symlink` section (new), document `-d`/`-D` semantics next to the usage examples, add the no-subcommands note and the stdout contract with a `tail -1` example.

## Test plan

Every documented claim was reproduced against a scratch repository with git-wt v0.29.0.

- [x] `--copy "node_modules/" --symlink "node_modules/"` in one invocation creates the symlink; `--symlink` alone creates nothing.
- [x] The resulting worktree reports `?? node_modules`, and `git wt -d` exits 1 with `has untracked files, use -D to force deletion`.
- [x] Adding `node_modules` to `.git/info/exclude` clears the status and lets `-d` succeed; dropping the trailing slash in `.gitignore` does the same.
- [x] With an unmerged branch, `git wt -d` removes the worktree, keeps the branch, and exits 0.
- [x] The worktree path is the last stdout line with hooks configured (hook output precedes it) and with git's progress output on stderr.
- [x] `git wt list` creates a `list` branch and `.wt/list` worktree.
- [x] `make lint` (0 issues), `go test ./...`, `go vet ./...`.