### PR TITLE
fix(add): keep -b authoritative when start-point is a remote-only branch

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -44,6 +44,40 @@ func LocalBranchExists(ctx context.Context, name string) (bool, error) {
 	return false, nil
 }
 
+// ResolvesToCommit reports whether name resolves to a commit under git's
+// normal revision rules (local branch, tag, remote-qualified ref such as
+// "origin/main", object name, "HEAD~1", ...). A bare branch name that exists
+// only on a remote does NOT resolve, which is exactly the case where
+// `git worktree add` falls back to branch DWIM.
+func ResolvesToCommit(ctx context.Context, name string) (bool, error) {
+	cmd, err := gitCommand(ctx, "rev-parse", "--verify", "--quiet", name+"^{commit}")
+	if err != nil {
+		return false, err
+	}
+	return cmd.Run() == nil, nil
+}
+
+// RemoteTrackingBranchesNamed returns the remote-tracking branches, in short
+// form (e.g. "origin/develop"), that exist under any remote with the given
+// bare branch name.
+func RemoteTrackingBranchesNamed(ctx context.Context, name string) ([]string, error) {
+	cmd, err := gitCommand(ctx, "for-each-ref", "--format=%(refname:short)", "refs/remotes/*/"+name)
+	if err != nil {
+		return nil, err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var refs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			refs = append(refs, line)
+		}
+	}
+	return refs, nil
+}
+
 // CreateBranch creates a new branch at the current HEAD.
 func CreateBranch(ctx context.Context, name string) error {
 	cmd, err := gitCommand(ctx, "branch", name)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/k1LoW/exec"
@@ -352,10 +353,66 @@ func AddWorktree(ctx context.Context, path, branch string, copyOpts CopyOptions)
 	return copyAfterAdd(ctx, ac, path, copyOpts)
 }
 
+// qualifyStartPoint rewrites a start point that names a branch existing only
+// on a remote to its remote-qualified form (e.g. "develop" -> "origin/develop").
+//
+// Since git v2.42.0 (commit 128e5496b3) `git worktree add -b <new-branch>
+// <path> <start-point>` applies branch DWIM when <start-point> does not
+// resolve locally but matches exactly one remote-tracking branch: -b is
+// silently dropped and a local branch named after <start-point> is created and
+// checked out instead. The worktree directory still carries <new-branch>, so
+// the mismatch is easy to miss and commits land on the wrong branch.
+// Qualifying the start point keeps -b authoritative.
+//
+// Anything that already resolves (local branch, tag, "origin/x", a SHA,
+// "HEAD~1", ...) and anything that resolves nowhere is passed through
+// untouched, so git keeps reporting its own errors.
+func qualifyStartPoint(ctx context.Context, startPoint string) (string, error) {
+	if startPoint == "" {
+		return startPoint, nil
+	}
+	resolves, err := ResolvesToCommit(ctx, startPoint)
+	if err != nil {
+		return "", err
+	}
+	if resolves {
+		return startPoint, nil
+	}
+
+	remotes, err := RemoteTrackingBranchesNamed(ctx, startPoint)
+	if err != nil {
+		return "", err
+	}
+	switch len(remotes) {
+	case 0:
+		return startPoint, nil
+	case 1:
+		fmt.Fprintf(os.Stderr, "Using %s as the start point ('%s' has no local branch)\n", remotes[0], startPoint)
+		return remotes[0], nil
+	}
+
+	// Ambiguous: git's own DWIM gives up here too. Honor the same config git
+	// uses to disambiguate before refusing.
+	if values, err := GitConfig(ctx, "checkout.defaultRemote"); err == nil && len(values) > 0 {
+		preferred := values[len(values)-1] + "/" + startPoint
+		if slices.Contains(remotes, preferred) {
+			fmt.Fprintf(os.Stderr, "Using %s as the start point (checkout.defaultRemote)\n", preferred)
+			return preferred, nil
+		}
+	}
+	return "", fmt.Errorf("start point %q has no local branch and matches several remotes (%s): qualify it (e.g. %s) or set checkout.defaultRemote",
+		startPoint, strings.Join(remotes, ", "), remotes[0])
+}
+
 // AddWorktreeWithNewBranch creates a new worktree with a new branch.
 // If startPoint is specified, the new branch will be created from that commit/branch.
 func AddWorktreeWithNewBranch(ctx context.Context, path, branch, startPoint string, copyOpts CopyOptions) error {
 	ac, err := prepareAdd(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	startPoint, err = qualifyStartPoint(ctx, startPoint)
 	if err != nil {
 		return err
 	}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -559,3 +559,87 @@ func TestRemoveWorktree_Force(t *testing.T) {
 		t.Error("worktree should not exist after force removal")
 	}
 }
+
+// pushAndDropLocal creates branch on the given remote and removes the local
+// copy, leaving it reachable only as <remote>/<branch>. This is the state that
+// triggers git's branch DWIM in `git worktree add -b`.
+func pushAndDropLocal(t *testing.T, repo *testutil.TestRepo, remote, branch string) {
+	t.Helper()
+	remoteDir := filepath.Join(t.TempDir(), remote+".git")
+	repo.Git("init", "--bare", remoteDir)
+	repo.Git("remote", "add", remote, remoteDir)
+	repo.Git("checkout", "-b", branch)
+	repo.Git("commit", "--allow-empty", "-m", "on "+branch)
+	repo.Git("push", remote, branch)
+	repo.Git("checkout", "main")
+	repo.Git("branch", "-D", branch)
+}
+
+func TestAddWorktreeWithNewBranch_RemoteOnlyStartPoint(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	repo.CreateFile("README.md", "# Test")
+	repo.Commit("initial commit")
+	pushAndDropLocal(t, repo, "origin", "develop")
+
+	restore := repo.Chdir()
+	defer restore()
+
+	wtPath := filepath.Join(repo.ParentDir(), "my-feature")
+	if err := AddWorktreeWithNewBranch(t.Context(), wtPath, "my-feature", "develop", CopyOptions{}); err != nil {
+		t.Fatalf("AddWorktreeWithNewBranch failed: %v", err)
+	}
+
+	// The requested branch must be the one checked out, not a local branch
+	// DWIM'd from the start point.
+	if got := repo.Git("-C", wtPath, "branch", "--show-current"); got != "my-feature" {
+		t.Errorf("checked out branch = %q, want %q", got, "my-feature")
+	}
+	exists, err := LocalBranchExists(t.Context(), "develop")
+	if err != nil {
+		t.Fatalf("LocalBranchExists failed: %v", err)
+	}
+	if exists {
+		t.Error("local branch \"develop\" was created, but only \"my-feature\" was requested")
+	}
+
+	// The start point must still be honored.
+	got := repo.Git("-C", wtPath, "rev-parse", "HEAD")
+	want := repo.Git("rev-parse", "refs/remotes/origin/develop")
+	if got != want {
+		t.Errorf("worktree HEAD = %s, want origin/develop (%s)", got, want)
+	}
+}
+
+func TestAddWorktreeWithNewBranch_RemoteOnlyStartPointAmbiguous(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	repo.CreateFile("README.md", "# Test")
+	repo.Commit("initial commit")
+	pushAndDropLocal(t, repo, "origin", "develop")
+	pushAndDropLocal(t, repo, "upstream", "develop")
+
+	restore := repo.Chdir()
+	defer restore()
+
+	wtPath := filepath.Join(repo.ParentDir(), "my-feature")
+	err := AddWorktreeWithNewBranch(t.Context(), wtPath, "my-feature", "develop", CopyOptions{})
+	if err == nil {
+		t.Fatal("expected an error for a start point matching several remotes, got nil")
+	}
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		t.Error("worktree was created despite the ambiguous start point")
+	}
+
+	// checkout.defaultRemote resolves the ambiguity, as it does for git itself.
+	repo.Git("config", "checkout.defaultRemote", "upstream")
+	if err := AddWorktreeWithNewBranch(t.Context(), wtPath, "my-feature", "develop", CopyOptions{}); err != nil {
+		t.Fatalf("AddWorktreeWithNewBranch with checkout.defaultRemote failed: %v", err)
+	}
+	if got := repo.Git("-C", wtPath, "branch", "--show-current"); got != "my-feature" {
+		t.Errorf("checked out branch = %q, want %q", got, "my-feature")
+	}
+	got := repo.Git("-C", wtPath, "rev-parse", "HEAD")
+	want := repo.Git("rev-parse", "refs/remotes/upstream/develop")
+	if got != want {
+		t.Errorf("worktree HEAD = %s, want upstream/develop (%s)", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #203.

## What goes wrong today

`git worktree add -b <new-branch> <path> <start-point>` applies git's branch DWIM when `<start-point>` does not resolve locally but matches exactly one remote-tracking branch: `-b` is silently dropped and a local branch named after `<start-point>` is created and checked out instead. The worktree directory still carries `<new-branch>`, so commits land on a branch the user never asked for.

Reproduced on the current `main` (20d020a) with git 2.54.0:

```
$ git wt my-feature develop      # develop exists only as origin/develop
Preparing worktree (new branch 'develop')
branch 'develop' set up to track 'origin/develop'.
$ git -C ../work-wt/my-feature branch --show-current
develop
```

As @yoichi established in the issue, this is a git regression introduced in v2.42.0 (git@128e5496). git-wt users will be on affected git versions for a long time either way, so the guard belongs here too.

## The change

`AddWorktreeWithNewBranch` now rewrites such a start point to its remote-qualified form (`develop` → `origin/develop`) before handing it to git, which keeps `-b` authoritative. This is option 2 from the issue, which @yoichi preferred, including the `checkout.defaultRemote` handling he asked for.

The rewrite is deliberately narrow — it only fires in exactly the state where git falls back to DWIM:

- start points that already resolve (local branch, tag, `origin/x`, a SHA, `HEAD~1`, …) are passed through untouched, so a tag named `develop` still wins the way git resolves it;
- start points that resolve nowhere are passed through untouched, so git keeps reporting its own `invalid reference` error;
- when several remotes carry the name, `checkout.defaultRemote` is honored; if it does not disambiguate, the ambiguity is reported with the candidates rather than silently guessed.

A one-line notice goes to stderr when a rewrite happens, so the substitution is visible.

`AddWorktree` (the existing-branch path) is intentionally left alone: it passes the branch as a commit-ish with no `-b`, and DWIM there is the behavior users want.

## Relationship to #208

Complementary, not overlapping. #208 stopped `cmd/root.go` from treating a remote-tracking branch as an existing local branch when a start point is given. That fixed the false `branch "foo" already exists` error; the `-b` clobber described here still happens on `main` today.

## Verification

Two regression tests in `internal/git/worktree_test.go`. Both assert the **effect** (which branch is actually checked out, and that the start point commit was honored), not just that the call succeeded.

I ran them against unpatched `main` first — negative control:

```
--- FAIL: TestAddWorktreeWithNewBranch_RemoteOnlyStartPoint
    checked out branch = "develop", want "my-feature"
    local branch "develop" was created, but only "my-feature" was requested
--- FAIL: TestAddWorktreeWithNewBranch_RemoteOnlyStartPointAmbiguous
    checked out branch = "develop", want "my-feature"
```

With the fix, `go test ./internal/git/ -run TestAddWorktreeWithNewBranch` is 4/4 green and `go vet ./...` is clean.

Full-suite caveat, in the interest of not overclaiming: I developed this on Windows, where `TestFindWorktreeByBranch` and `TestFindWorktreeByBranchOrDir_SkipsBare` fail on a **pristine** checkout too (path separator, `C:/…` vs `C:\…`). I confirmed both fail without my change, so they are pre-existing and unrelated, but it does mean I have not run the e2e package end to end — it sets `GIT_CONFIG_GLOBAL=/dev/null`, which is not meaningful on Windows. CI will cover that.

I did not add an e2e test for this; happy to add one if you would prefer the coverage at that layer.
