### PR TITLE
ci: report coverage for every run

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -14,6 +14,5 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
The report condition currently limits artifact storage to the default branch, so pull request coverage reports are not retained.

Remove the condition now that octocov derives ref-specific report keys. Reports from every run can be stored, while `diff.datastores:` continues comparing against the default branch report.