### PR TITLE
Checkout remote branch other than origin without start-point

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -348,6 +348,127 @@ func TestE2E_CreateWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("with_remote", func(t *testing.T) {
+		t.Parallel()
+		// Create the "origin" repo
+		originRepo := testutil.NewTestRepo(t)
+		originRepo.CreateFile("README_origin.md", "# Origin")
+		originRepo.Commit("origin initial commit")
+		originRepo.Git("branch", "origin-only")
+		originRepo.CreateFile("origin-file.txt", "origin content")
+		originRepo.Commit("origin second commit")
+		originRepo.Git("branch", "remote-common-name")
+
+		// Create the "other" repo
+		otherRepo := testutil.NewTestRepo(t)
+		otherRepo.CreateFile("README_other.md", "# Other")
+		otherRepo.Commit("other initial commit")
+		otherRepo.Git("branch", "other-only")
+		otherRepo.CreateFile("other-file.txt", "other content")
+		otherRepo.Commit("other second commit")
+		otherRepo.Git("branch", "remote-common-name")
+
+		// Clone the "origin" repo
+		cloneDir := t.TempDir()
+		clonePath := filepath.Join(cloneDir, "clone")
+		cmd := exec.Command("git", "clone", originRepo.Root, clonePath)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git clone failed: %v\noutput: %s", err, out)
+		}
+
+		// Add and fetch the "other" repo
+		cmd = exec.Command("git", "remote", "add", "other", otherRepo.Root)
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git checkout failed: %v\noutput: %s", err, out)
+		}
+		cmd = exec.Command("git", "fetch", "other")
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git fetch other failed: %v\noutput: %s", err, out)
+		}
+
+		var out, wtPath, remoteFilePath string
+		var err error
+
+		// origin-only
+		out, err = runGitWt(t, binPath, clonePath, "origin-only")
+		if err != nil {
+			t.Fatalf("git-wt origin-only failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "origin/origin-only") {
+			t.Fatalf("output should contain worktree path with 'origin/origin-only', got: %s", out)
+		}
+		wtPath = worktreePath(out)
+		if _, err = os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory was not created at %s", wtPath)
+		}
+		// Verify the worktree is based on the first commit on origin
+		remoteFilePath = filepath.Join(wtPath, "README_origin.md")
+		if _, err = os.Stat(remoteFilePath); os.IsNotExist(err) {
+			t.Error("worktree should have README_origin.md (should be based on origin/origin-only)")
+		}
+		remoteFilePath = filepath.Join(wtPath, "origin-file.txt")
+		if _, err = os.Stat(remoteFilePath); !os.IsNotExist(err) {
+			t.Error("worktree should NOT have origin-file.txt (should be based on origin/origin-only)")
+		}
+
+		// other-only
+		out, err = runGitWt(t, binPath, clonePath, "other-only")
+		if err != nil {
+			t.Fatalf("git-wt other-only failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "other/other-only") {
+			t.Fatalf("output should contain worktree path with 'other/other-only', got: %s", out)
+		}
+		wtPath = worktreePath(out)
+		if _, err = os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory was not created at %s", wtPath)
+		}
+		// Verify the worktree is based on the first commit on other
+		remoteFilePath = filepath.Join(wtPath, "README_other.md")
+		if _, err = os.Stat(remoteFilePath); os.IsNotExist(err) {
+			t.Error("worktree should have README_other.md (should be based on other/other-only)")
+		}
+		remoteFilePath = filepath.Join(wtPath, "other-file.txt")
+		if _, err = os.Stat(remoteFilePath); !os.IsNotExist(err) {
+			t.Error("worktree should NOT have other-file.txt (should be based on other/other-only)")
+		}
+
+		// ambiguous name without checkout.defaultRemote
+		out, err = runGitWt(t, binPath, clonePath, "remote-common-name")
+		if err == nil {
+			t.Fatalf("git-wt remote-common-name didn't fail: %v\noutput: %s", err, out)
+		}
+
+		// ambiguous name with checkout.defaultRemote
+		cmd = exec.Command("git", "config", "checkout.defaultRemote", "other")
+		cmd.Dir = clonePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git fetch other failed: %v\noutput: %s", err, out)
+		}
+		out, err = runGitWt(t, binPath, clonePath, "remote-common-name")
+		if err != nil {
+			t.Fatalf("git-wt remote-common-name failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "other/remote-common-name") {
+			t.Fatalf("output should contain worktree path with 'other/remote-common-name', got: %s", out)
+		}
+		wtPath = worktreePath(out)
+		if _, err = os.Stat(wtPath); os.IsNotExist(err) {
+			t.Fatalf("worktree directory was not created at %s", wtPath)
+		}
+		// Verify the worktree is based on the second commit on other
+		remoteFilePath = filepath.Join(wtPath, "README_other.md")
+		if _, err = os.Stat(remoteFilePath); os.IsNotExist(err) {
+			t.Error("worktree should have README_other.md (should be based on other/remote-common-name)")
+		}
+		remoteFilePath = filepath.Join(wtPath, "other-file.txt")
+		if _, err = os.Stat(remoteFilePath); os.IsNotExist(err) {
+			t.Error("worktree should have other-file.txt (should be based on other/remote-common-name)")
+		}
+	})
+
 	t.Run("with_remote_start_point", func(t *testing.T) {
 		t.Parallel()
 		// Create a "remote" repo

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -12,24 +12,20 @@ const gitDefaultBranch = "master"
 // BranchExists checks if a branch exists (local or remote).
 func BranchExists(ctx context.Context, name string) (bool, error) {
 	// Check local branch
-	cmd, err := gitCommand(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+name)
+	exists, err := LocalBranchExists(ctx, name)
 	if err != nil {
 		return false, err
 	}
-	if err := cmd.Run(); err == nil {
+	if exists {
 		return true, nil
 	}
 
-	// Check remote branch (origin)
-	cmd, err = gitCommand(ctx, "show-ref", "--verify", "--quiet", "refs/remotes/origin/"+name)
+	// Check remote branch
+	remotes, err := RemoteTrackingBranchesNamed(ctx, name)
 	if err != nil {
 		return false, err
 	}
-	if err := cmd.Run(); err == nil {
-		return true, nil
-	}
-
-	return false, nil
+	return len(remotes) > 0, nil
 }
 
 // LocalBranchExists checks if a local branch exists.

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -8,10 +8,25 @@ import (
 )
 
 func TestBranchExists(t *testing.T) {
+	originRepo := testutil.NewTestRepo(t)
+	originRepo.CreateFile("README.md", "# Test")
+	originRepo.Commit("initial commit")
+	originRepo.Git("branch", "origin-only")
+	originRepo.Git("branch", "remote-common-name")
+
+	otherRepo := testutil.NewTestRepo(t)
+	otherRepo.CreateFile("README.md", "# Test")
+	otherRepo.Commit("initial commit")
+	otherRepo.Git("branch", "other-only")
+	otherRepo.Git("branch", "remote-common-name")
+
 	repo := testutil.NewTestRepo(t)
 	repo.CreateFile("README.md", "# Test")
 	repo.Commit("initial commit")
 	repo.Git("branch", "feature")
+	repo.Git("remote", "add", "origin", originRepo.Root)
+	repo.Git("remote", "add", "other", otherRepo.Root)
+	repo.Git("fetch", "--all")
 
 	restore := repo.Chdir()
 	defer restore()
@@ -24,6 +39,9 @@ func TestBranchExists(t *testing.T) {
 		{"existing local branch", "feature", true},
 		{"main branch", "main", true},
 		{"non-existing branch", "no-such-branch", false},
+		{"branch on origin", "origin-only", true},
+		{"branch on other", "other-only", true},
+		{"branch on origin and other", "remote-common-name", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Suppose a branch exist on a remote other than origin, currently we have to specify the second argument 'start-point' to create branch and track it (without start-point, git-wt creates branch from HEAD instead). Improve the check for the existence of remote branches by using the recently added `RemoteTrackingBranchesNamed()` function.

Error handling for cases where multiple remotes match is left to the git command itself (in git 2.55.0, this results in the unhelpful message "fatal: invalid reference", but this is scheduled to be improved in the next version).